### PR TITLE
Add theme variables for Tailwind

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -57,6 +57,13 @@
   --neutral-700: #404040;
   --neutral-800: #262626;
   --neutral-900: #171717;
+
+  /* Theme extensions */
+  --background: #ffffff;
+  --muted: #f5f5f5;
+  --muted-foreground: #6b7280;
+  --destructive: #ef4444;
+  --destructive-foreground: #ffffff;
 }
 
 @layer base {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -62,6 +62,15 @@ export default {
           800: 'var(--neutral-800)',
           900: 'var(--neutral-900)',
         },
+        destructive: {
+          DEFAULT: 'var(--destructive)',
+          foreground: 'var(--destructive-foreground)',
+        },
+        background: 'var(--background)',
+        muted: {
+          DEFAULT: 'var(--muted)',
+          foreground: 'var(--muted-foreground)',
+        },
       },
       boxShadow: {
         'sm': '0 1px 2px 0 rgba(0, 0, 0, 0.05)',


### PR DESCRIPTION
## Summary
- define new CSS variables for destructive and muted colors
- map background, muted and destructive colors in tailwind config

## Testing
- `npm run lint` *(fails: 1 error, 478 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685882e26a04832892bff9f5bd45eb09