### PR TITLE
Remove redundant Toaster

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { HashRouter, Routes, Route, Navigate } from 'react-router-dom';
-import { Toaster } from 'sonner';
 
 // Providers
 import { ShopProvider } from './contexts/ShopContext';
@@ -182,7 +181,6 @@ const AppRoutes = () => {
                 <Route path="*" element={<Navigate to="/\" replace />} />
               </Routes>
               
-              <Toaster position="top-right" expand={true} richColors />
               <ChatbotWidget />
             </ShopProvider>
           </RoleProvider>


### PR DESCRIPTION
## Summary
- keep `<Toaster />` only in `App.tsx`
- remove duplicate `Toaster` import/usage from routes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685882d5002c8328b62e077ba056642e