### PR TITLE
Add analytics service and hooks

### DIFF
--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -1,0 +1,81 @@
+import { useState, useEffect } from 'react';
+
+import { analyticsService, DailyImportCount, SalesData, SeoScore } from '../services/analyticsService';
+
+export function useDailyImportCounts() {
+  const [data, setData] = useState<DailyImportCount[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const counts = await analyticsService.getDailyImportCounts();
+      setData(counts);
+    } catch (err: any) {
+      console.error('Error fetching import counts:', err);
+      setError(err.message || 'Failed to load import analytics');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  return { data, loading, error, refetch: fetchData };
+}
+
+export function useSalesAnalytics() {
+  const [data, setData] = useState<SalesData[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const sales = await analyticsService.getSalesData();
+      setData(sales);
+    } catch (err: any) {
+      console.error('Error fetching sales analytics:', err);
+      setError(err.message || 'Failed to load sales analytics');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  return { data, loading, error, refetch: fetchData };
+}
+
+export function useSeoScores() {
+  const [data, setData] = useState<SeoScore[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const scores = await analyticsService.getSeoScores();
+      setData(scores);
+    } catch (err: any) {
+      console.error('Error fetching SEO scores:', err);
+      setError(err.message || 'Failed to load SEO scores');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  return { data, loading, error, refetch: fetchData };
+}

--- a/src/pages/Documentation.tsx
+++ b/src/pages/Documentation.tsx
@@ -142,7 +142,7 @@ async function importProduct(url) {
     console.log('Produit importé avec succès:', product.id);
     return product;
   } catch (error) {
-    console.error('Erreur lors de l\'importation:', error);
+    console.error("Erreur lors de l'importation:", error);
   }
 }`
       }

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -1,0 +1,97 @@
+import { supabase } from '../lib/supabase';
+
+export interface DailyImportCount {
+  date: string;
+  count: number;
+}
+
+export interface SalesData {
+  date: string;
+  orders: number;
+  revenue: number;
+}
+
+export interface SeoScore {
+  product_id: string;
+  score: number;
+  updated_at: string;
+}
+
+export const analyticsService = {
+  async getDailyImportCounts(days = 30): Promise<DailyImportCount[]> {
+    try {
+      const since = new Date();
+      since.setDate(since.getDate() - (days - 1));
+
+      const { data, error } = await supabase
+        .from('product_imports')
+        .select('id, created_at')
+        .gte('created_at', since.toISOString());
+
+      if (error) throw error;
+
+      const counts: Record<string, number> = {};
+      for (const row of data || []) {
+        const date = row.created_at.split('T')[0];
+        counts[date] = (counts[date] || 0) + 1;
+      }
+
+      return Object.entries(counts)
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([date, count]) => ({ date, count }));
+    } catch (error) {
+      console.error('Error fetching daily import counts:', error);
+      throw error;
+    }
+  },
+
+  async getSalesData(days = 30): Promise<SalesData[]> {
+    try {
+      const since = new Date();
+      since.setDate(since.getDate() - (days - 1));
+      const fromDate = since.toISOString().split('T')[0];
+
+      const { data, error } = await supabase
+        .from('marketplace_analytics')
+        .select('conversions, revenue, date')
+        .gte('date', fromDate);
+
+      if (error) throw error;
+
+      const totals: Record<string, { orders: number; revenue: number }> = {};
+      for (const row of data || []) {
+        if (!totals[row.date]) {
+          totals[row.date] = { orders: 0, revenue: 0 };
+        }
+        totals[row.date].orders += row.conversions || 0;
+        totals[row.date].revenue += row.revenue || 0;
+      }
+
+      return Object.entries(totals)
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([date, { orders, revenue }]) => ({ date, orders, revenue }));
+    } catch (error) {
+      console.error('Error fetching sales data:', error);
+      throw error;
+    }
+  },
+
+  async getSeoScores(): Promise<SeoScore[]> {
+    try {
+      const { data, error } = await supabase
+        .from('seo_scores')
+        .select('*');
+
+      if (error) {
+        // If table doesn't exist, return empty array
+        if (error.code === '42P01') return [];
+        throw error;
+      }
+
+      return data || [];
+    } catch (error) {
+      console.error('Error fetching SEO scores:', error);
+      throw error;
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- add analyticsService with helpers for product imports, sales data and SEO scores
- provide hooks to consume these analytics in the app
- fix lint error in Documentation page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685880f01b5c83288740b634daf46767