### PR TITLE
Add workspace settings support

### DIFF
--- a/src/contexts/WorkspaceContext.tsx
+++ b/src/contexts/WorkspaceContext.tsx
@@ -1,0 +1,85 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+import { supabase } from '../lib/supabase';
+
+export interface Workspace {
+  id: string;
+  owner_id: string;
+  name: string;
+  timezone: string;
+  currency: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface WorkspaceContextType {
+  workspace: Workspace | null;
+  loading: boolean;
+  refresh: () => Promise<void>;
+  update: (values: Partial<Pick<Workspace, 'name' | 'timezone' | 'currency'>>) => Promise<void>;
+}
+
+const WorkspaceContext = createContext<WorkspaceContextType | undefined>(undefined);
+
+export const WorkspaceProvider = ({ children }: { children: ReactNode }) => {
+  const [workspace, setWorkspace] = useState<Workspace | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchWorkspace = async () => {
+    setLoading(true);
+    const { data: { session } } = await supabase.auth.getSession();
+    const userId = session?.user?.id;
+    if (!userId) {
+      setWorkspace(null);
+      setLoading(false);
+      return;
+    }
+    const { data } = await supabase
+      .from('workspaces')
+      .select('*')
+      .eq('owner_id', userId)
+      .single();
+    if (data) {
+      setWorkspace(data as Workspace);
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchWorkspace();
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(() => {
+      fetchWorkspace();
+    });
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  const update = async (values: Partial<Pick<Workspace, 'name' | 'timezone' | 'currency'>>) => {
+    const { data: { session } } = await supabase.auth.getSession();
+    const userId = session?.user?.id;
+    if (!userId) return;
+    const updates = { ...workspace, ...values, owner_id: userId } as Partial<Workspace> & { owner_id: string };
+    const { data } = await supabase
+      .from('workspaces')
+      .upsert(updates, { onConflict: 'owner_id' })
+      .select()
+      .single();
+    if (data) {
+      setWorkspace(data as Workspace);
+    }
+  };
+
+  return (
+    <WorkspaceContext.Provider value={{ workspace, loading, refresh: fetchWorkspace, update }}>
+      {children}
+    </WorkspaceContext.Provider>
+  );
+};
+
+export const useWorkspace = () => {
+  const context = useContext(WorkspaceContext);
+  if (!context) throw new Error('useWorkspace must be used within a WorkspaceProvider');
+  return context;
+};
+

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { BarChart3, ShoppingBag, TrendingUp, Users, ArrowUpRight, ArrowDownRight, Package, Calendar, Bell, Settings, FileText, Bot, Database, Code, Layers, Webhook } from 'lucide-react';
 
 import { supabase } from '../lib/supabase';
+import { useWorkspace } from '../contexts/WorkspaceContext';
 import SubscriptionOverview from '../components/dashboard/SubscriptionOverview';
 import TrackingWidget from '../components/tracking/TrackingWidget';
 import MainNavbar from '../components/layout/MainNavbar';
@@ -10,6 +11,7 @@ import Footer from '../components/layout/Footer';
 import { Button } from '../components/ui/button';
 
 export default function Dashboard() {
+  const { workspace } = useWorkspace();
   const [stats, setStats] = useState({
     revenue: { value: 1060, change: 25 },
     orders: { value: 98, change: 12 },
@@ -84,7 +86,12 @@ export default function Dashboard() {
                 <DollarSign className="h-5 w-5 text-blue-500" />
               </div>
             </div>
-            <p className="text-2xl font-bold">{stats.revenue.value.toLocaleString()}€</p>
+            <p className="text-2xl font-bold">
+              {stats.revenue.value.toLocaleString(undefined, {
+                style: 'currency',
+                currency: workspace?.currency || 'EUR'
+              })}
+            </p>
             <div className="flex items-center mt-2">
               <span className={`flex items-center text-sm ${stats.revenue.change >= 0 ? 'text-green-500' : 'text-red-500'}`}>
                 {stats.revenue.change >= 0 ? (
@@ -264,7 +271,7 @@ export default function Dashboard() {
               <Calendar className="h-6 w-6 text-blue-500 mr-3" />
               <div>
                 <h3 className="font-medium">Aujourd'hui</h3>
-                <p className="text-sm text-gray-600">{new Date().toLocaleDateString('fr-FR', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}</p>
+                <p className="text-sm text-gray-600">{new Date().toLocaleDateString('fr-FR', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', timeZone: workspace?.timezone })}</p>
               </div>
             </div>
             <div className="flex space-x-2">

--- a/src/pages/Documentation.tsx
+++ b/src/pages/Documentation.tsx
@@ -142,7 +142,7 @@ async function importProduct(url) {
     console.log('Produit importé avec succès:', product.id);
     return product;
   } catch (error) {
-    console.error('Erreur lors de l\'importation:', error);
+    console.error('Erreur lors de l'importation:', error);
   }
 }`
       }

--- a/src/pages/WorkspaceSettings.tsx
+++ b/src/pages/WorkspaceSettings.tsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from 'react';
+import { Navigate } from 'react-router-dom';
+
+import { useRole } from '../context/RoleContext';
+import { useWorkspace } from '../contexts/WorkspaceContext';
+import { availableCurrencies } from '../contexts/CurrencyContext';
+import { Button } from '../components/ui/button';
+
+const timezones = [
+  'UTC',
+  'Europe/Paris',
+  'America/New_York',
+  'Asia/Tokyo'
+];
+
+const WorkspaceSettings: React.FC = () => {
+  const { isAdmin, loading: roleLoading } = useRole();
+  const { workspace, update, loading } = useWorkspace();
+  const [name, setName] = useState('');
+  const [timezone, setTimezone] = useState('UTC');
+  const [currency, setCurrency] = useState('USD');
+
+  useEffect(() => {
+    if (workspace) {
+      setName(workspace.name);
+      setTimezone(workspace.timezone);
+      setCurrency(workspace.currency);
+    }
+  }, [workspace]);
+
+  if (!roleLoading && !isAdmin) {
+    return <Navigate to="/app/dashboard" replace />;
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await update({ name, timezone, currency });
+  };
+
+  return (
+    <div className="p-6 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Workspace Settings</h1>
+      <form className="space-y-4" onSubmit={handleSubmit}>
+        <div>
+          <label className="block text-sm font-medium mb-1">Store Name</label>
+          <input
+            className="w-full px-3 py-2 border border-gray-300 rounded-md"
+            value={name}
+            onChange={e => setName(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Time Zone</label>
+          <select
+            className="w-full px-3 py-2 border border-gray-300 rounded-md"
+            value={timezone}
+            onChange={e => setTimezone(e.target.value)}
+          >
+            {timezones.map(tz => (
+              <option key={tz} value={tz}>
+                {tz}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Currency</label>
+          <select
+            className="w-full px-3 py-2 border border-gray-300 rounded-md"
+            value={currency}
+            onChange={e => setCurrency(e.target.value)}
+          >
+            {availableCurrencies.map(cur => (
+              <option key={cur} value={cur}>
+                {cur}
+              </option>
+            ))}
+          </select>
+        </div>
+        <Button type="submit" disabled={loading}>
+          Save
+        </Button>
+      </form>
+    </div>
+  );
+};
+
+export default WorkspaceSettings;

--- a/src/pages/accounting/index.tsx
+++ b/src/pages/accounting/index.tsx
@@ -4,9 +4,11 @@ import { toast } from 'sonner';
 
 import { accountingService, Invoice } from '../../modules/accounting';
 import { Button } from '../../components/ui/button';
+import { useWorkspace } from '../../contexts/WorkspaceContext';
 
 
 const AccountingPage: React.FC = () => {
+  const { workspace } = useWorkspace();
   const [invoices, setInvoices] = useState<Invoice[]>([]);
   const [loading, setLoading] = useState(true);
   const [selectedInvoice, setSelectedInvoice] = useState<Invoice | null>(null);
@@ -138,11 +140,11 @@ const AccountingPage: React.FC = () => {
   };
   
   const formatDate = (date: Date) => {
-    return date.toLocaleDateString();
+    return date.toLocaleDateString('fr-FR', { timeZone: workspace?.timezone });
   };
   
   const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(amount);
+    return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: workspace?.currency || 'EUR' }).format(amount);
   };
   
   return (

--- a/src/pages/admin/Analytics.tsx
+++ b/src/pages/admin/Analytics.tsx
@@ -4,11 +4,13 @@ import { Navigate } from 'react-router-dom';
 
 import { supabase } from '../../lib/supabase';
 import { useRole } from '../../context/RoleContext';
+import { useWorkspace } from '../../contexts/WorkspaceContext';
 import { Button } from '../../components/ui/button';
 
 
 const AdminAnalytics: React.FC = () => {
   const { isAdmin, loading: roleLoading } = useRole();
+  const { workspace } = useWorkspace();
   const [loading, setLoading] = useState(true);
   const [period, setPeriod] = useState('30days');
   const [stats, setStats] = useState({
@@ -98,7 +100,12 @@ const AdminAnalytics: React.FC = () => {
               <DollarSign className="h-5 w-5 text-blue-500" />
             </div>
           </div>
-          <p className="text-2xl font-bold">{stats.revenue.toLocaleString()}€</p>
+          <p className="text-2xl font-bold">
+            {stats.revenue.toLocaleString(undefined, {
+              style: 'currency',
+              currency: workspace?.currency || 'EUR'
+            })}
+          </p>
           <div className="flex items-center mt-2">
             <span className={`flex items-center text-sm ${stats.revenueGrowth >= 0 ? 'text-green-500' : 'text-red-500'}`}>
               {stats.revenueGrowth >= 0 ? (
@@ -157,7 +164,12 @@ const AdminAnalytics: React.FC = () => {
           </div>
           <p className="text-2xl font-bold">{stats.conversionRate}%</p>
           <div className="flex items-center mt-2">
-            <span className="text-sm text-gray-600">Panier moyen: {stats.averageOrderValue.toFixed(2)}€</span>
+            <span className="text-sm text-gray-600">
+              Panier moyen: {stats.averageOrderValue.toLocaleString(undefined, {
+                style: 'currency',
+                currency: workspace?.currency || 'EUR'
+              })}
+            </span>
           </div>
         </div>
       </div>
@@ -191,7 +203,10 @@ const AdminAnalytics: React.FC = () => {
                     <div className="h-10 w-10 bg-gray-200 rounded-md mr-3"></div>
                     <div>
                       <div className="font-medium text-gray-900">Produit {i + 1}</div>
-                      <div className="text-xs text-gray-500">{(99.99 - i * 10).toFixed(2)}€</div>
+                      <div className="text-xs text-gray-500">{(99.99 - i * 10).toLocaleString(undefined, {
+                        style: 'currency',
+                        currency: workspace?.currency || 'EUR'
+                      })}</div>
                     </div>
                   </div>
                   <div className="text-sm font-medium">{100 - i * 15} ventes</div>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -8,6 +8,7 @@ import { UserProvider } from './contexts/UserContext';
 import { LanguageProvider } from './contexts/LanguageContext';
 import { CurrencyProvider } from './contexts/CurrencyContext';
 import { RoleProvider } from './context/RoleContext';
+import { WorkspaceProvider } from './contexts/WorkspaceContext';
 
 // Layouts
 import Layout from './components/layout/Layout';
@@ -63,6 +64,7 @@ import Analytics from './pages/Analytics';
 import Reviews from './pages/Reviews';
 import Suppliers from './pages/Suppliers';
 import Settings from './pages/Settings';
+import WorkspaceSettings from './pages/WorkspaceSettings';
 import Support from './pages/Support';
 import Contact from './pages/Contact';
 import Subscription from './pages/Account/Subscription';
@@ -90,7 +92,8 @@ const AppRoutes = () => {
         <CurrencyProvider>
           <UserProvider>
             <RoleProvider>
-              <ShopProvider>
+              <WorkspaceProvider>
+                <ShopProvider>
               <SubscriptionBanner />
               <Routes>
                 {/* Public pages */}
@@ -133,6 +136,7 @@ const AppRoutes = () => {
                   <Route path="reviews" element={<Reviews />} />
                   <Route path="suppliers" element={<Suppliers />} />
                   <Route path="settings" element={<Settings />} />
+                  <Route path="workspace-settings" element={<WorkspaceSettings />} />
                   <Route path="support" element={<Support />} />
                   <Route path="contact" element={<Contact />} />
                   <Route path="subscription" element={<Subscription />} />
@@ -185,6 +189,7 @@ const AppRoutes = () => {
               <Toaster position="top-right" expand={true} richColors />
               <ChatbotWidget />
             </ShopProvider>
+          </WorkspaceProvider>
           </RoleProvider>
         </UserProvider>
         </CurrencyProvider>

--- a/supabase/migrations/20250606010000_workspace_settings.sql
+++ b/supabase/migrations/20250606010000_workspace_settings.sql
@@ -1,0 +1,44 @@
+/*
+  # Create workspaces table
+
+  1. New Tables
+    - `workspaces` - Stores workspace settings per user
+      - `id` uuid primary key
+      - `owner_id` uuid references auth.users
+      - `name` text
+      - `timezone` text
+      - `currency` text
+      - `created_at` timestamp
+      - `updated_at` timestamp
+
+  2. Security
+    - Enable RLS so only owner or admins/managers can update the row
+*/
+
+CREATE TABLE IF NOT EXISTS workspaces (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_id uuid REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+  name text NOT NULL,
+  timezone text NOT NULL DEFAULT 'UTC',
+  currency text NOT NULL DEFAULT 'USD',
+  created_at timestamptz DEFAULT now() NOT NULL,
+  updated_at timestamptz DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_workspaces_owner_id ON workspaces(owner_id);
+
+ALTER TABLE workspaces ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Workspace owners can manage" ON workspaces
+  FOR ALL
+  USING (
+    owner_id = auth.uid() OR EXISTS (
+      SELECT 1 FROM users u WHERE u.id = auth.uid() AND u.role IN ('admin','superadmin')
+    )
+  )
+  WITH CHECK (
+    owner_id = auth.uid() OR EXISTS (
+      SELECT 1 FROM users u WHERE u.id = auth.uid() AND u.role IN ('admin','superadmin')
+    )
+  );
+


### PR DESCRIPTION
## Summary
- add `workspaces` table with RLS migration
- provide `WorkspaceContext` for loading and updating workspace settings
- add workspace settings page
- show workspace currency and timezone in dashboard, admin analytics and accounting pages
- hook workspace provider into the app routes
- fix lint error in documentation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68588147d0f4832895a0bc67802fe7a0