### PR TITLE
Add sync status icons

### DIFF
--- a/src/components/integrations/PlatformConnector.tsx
+++ b/src/components/integrations/PlatformConnector.tsx
@@ -22,6 +22,7 @@ interface PlatformConnectorProps {
     logo: string;
     type: 'marketplace' | 'webstore' | 'social';
     connected: boolean;
+    syncStatus?: 'synced' | 'error' | 'pending';
   };
   onConnect: (platform: string, credentials: any) => Promise<boolean>;
   onDisconnect: (platform: string) => Promise<boolean>;
@@ -171,7 +172,27 @@ const PlatformConnector: React.FC<PlatformConnectorProps> = ({
             </div>
           )}
           <div>
-            <h3 className="font-medium text-gray-900">{platform.name}</h3>
+            <div className="flex items-center space-x-2">
+              <h3 className="font-medium text-gray-900">{platform.name}</h3>
+              {platform.syncStatus && (
+                <span className="flex items-center text-xs font-medium">
+                  <span
+                    className={`h-2 w-2 rounded-full mr-1 ${
+                      platform.syncStatus === 'synced'
+                        ? 'bg-green-500'
+                        : platform.syncStatus === 'error'
+                        ? 'bg-red-500'
+                        : 'bg-yellow-500'
+                    }`}
+                  />
+                  {platform.syncStatus === 'synced'
+                    ? 'Synced'
+                    : platform.syncStatus === 'error'
+                    ? 'Échec'
+                    : 'En attente'}
+                </span>
+              )}
+            </div>
             <p className="text-sm text-gray-500 capitalize">{platform.type}</p>
           </div>
         </div>

--- a/src/components/integrations/PlatformStatus.tsx
+++ b/src/components/integrations/PlatformStatus.tsx
@@ -17,6 +17,7 @@ interface PlatformStatusProps {
     name: string;
     connected: boolean;
     status?: 'active' | 'error' | 'warning' | 'maintenance';
+    syncStatus?: 'synced' | 'error' | 'pending';
     lastSync?: string;
     metrics?: {
       products: number;
@@ -93,7 +94,27 @@ const PlatformStatus: React.FC<PlatformStatusProps> = ({ platforms, onRefresh })
                       {getStatusIcon(platform.status)}
                     </div>
                     <div>
-                      <h4 className="font-medium">{platform.name}</h4>
+                      <div className="flex items-center space-x-2">
+                        <h4 className="font-medium">{platform.name}</h4>
+                        {platform.syncStatus && (
+                          <span className="flex items-center text-xs font-medium">
+                            <span
+                              className={`h-2 w-2 rounded-full mr-1 ${
+                                platform.syncStatus === 'synced'
+                                  ? 'bg-green-500'
+                                  : platform.syncStatus === 'error'
+                                  ? 'bg-red-500'
+                                  : 'bg-yellow-500'
+                              }`}
+                            />
+                            {platform.syncStatus === 'synced'
+                              ? 'Synced'
+                              : platform.syncStatus === 'error'
+                              ? 'Échec'
+                              : 'En attente'}
+                          </span>
+                        )}
+                      </div>
                       <p className="text-sm text-gray-500">
                         Last synced: {formatDate(platform.lastSync)}
                       </p>
@@ -155,7 +176,27 @@ const PlatformStatus: React.FC<PlatformStatusProps> = ({ platforms, onRefresh })
                       <XCircle className="h-5 w-5 text-gray-400" />
                     </div>
                     <div>
-                      <h4 className="font-medium">{platform.name}</h4>
+                      <div className="flex items-center space-x-2">
+                        <h4 className="font-medium">{platform.name}</h4>
+                        {platform.syncStatus && (
+                          <span className="flex items-center text-xs font-medium">
+                            <span
+                              className={`h-2 w-2 rounded-full mr-1 ${
+                                platform.syncStatus === 'synced'
+                                  ? 'bg-green-500'
+                                  : platform.syncStatus === 'error'
+                                  ? 'bg-red-500'
+                                  : 'bg-yellow-500'
+                              }`}
+                            />
+                            {platform.syncStatus === 'synced'
+                              ? 'Synced'
+                              : platform.syncStatus === 'error'
+                              ? 'Échec'
+                              : 'En attente'}
+                          </span>
+                        )}
+                      </div>
                       <p className="text-sm text-gray-500">Not connected</p>
                     </div>
                   </div>

--- a/src/pages/Documentation.tsx
+++ b/src/pages/Documentation.tsx
@@ -142,7 +142,7 @@ async function importProduct(url) {
     console.log('Produit importé avec succès:', product.id);
     return product;
   } catch (error) {
-    console.error('Erreur lors de l\'importation:', error);
+    console.error('Erreur lors de l'importation:', error);
   }
 }`
       }

--- a/src/pages/MultiPlatformIntegration.tsx
+++ b/src/pages/MultiPlatformIntegration.tsx
@@ -35,14 +35,16 @@ const MultiPlatformIntegration: React.FC = () => {
       logo: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/0e/Shopify_logo_2018.svg/2560px-Shopify_logo_2018.svg.png',
       type: 'webstore' as const,
       connected: true,
-      lastSync: '2025-06-15T14:30:00Z'
+      lastSync: '2025-06-15T14:30:00Z',
+      syncStatus: 'synced' as const
     },
     {
       id: 'woocommerce',
       name: 'WooCommerce',
       logo: 'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Woocommerce_logo.svg/2560px-Woocommerce_logo.svg.png',
       type: 'webstore' as const,
-      connected: false
+      connected: false,
+      syncStatus: 'pending' as const
     },
     {
       id: 'amazon',
@@ -50,28 +52,32 @@ const MultiPlatformIntegration: React.FC = () => {
       logo: 'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a9/Amazon_logo.svg/1024px-Amazon_logo.svg.png',
       type: 'marketplace' as const,
       connected: true,
-      lastSync: '2025-06-14T10:15:00Z'
+      lastSync: '2025-06-14T10:15:00Z',
+      syncStatus: 'error' as const
     },
     {
       id: 'etsy',
       name: 'Etsy',
       logo: 'https://upload.wikimedia.org/wikipedia/commons/thumb/8/89/Etsy_logo.svg/2560px-Etsy_logo.svg.png',
       type: 'marketplace' as const,
-      connected: false
+      connected: false,
+      syncStatus: 'pending' as const
     },
     {
       id: 'bigcommerce',
       name: 'BigCommerce',
       logo: 'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7a/Bigcommerce_logo.svg/1280px-Bigcommerce_logo.svg.png',
       type: 'webstore' as const,
-      connected: false
+      connected: false,
+      syncStatus: 'pending' as const
     },
     {
       id: 'squarespace',
       name: 'Squarespace',
       logo: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/Squarespace_logo.svg/1280px-Squarespace_logo.svg.png',
       type: 'webstore' as const,
-      connected: false
+      connected: false,
+      syncStatus: 'pending' as const
     }
   ]);
 


### PR DESCRIPTION
## Summary
- add `syncStatus` field to platform objects
- show sync state icons in `PlatformConnector` and `PlatformStatus`
- include sample sync statuses on MultiPlatformIntegration page
- fix lint error in Documentation page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685c221b24c48328975b3996815eb780