### PR TITLE
Add new platform handlers and tests

### DIFF
--- a/backend/api/connect.py
+++ b/backend/api/connect.py
@@ -39,9 +39,64 @@ async def validate_woocommerce(creds: dict) -> tuple[bool, str | None]:
     except Exception as e:
         return False, str(e)
 
+async def validate_ebay(creds: dict) -> tuple[bool, str | None]:
+    token = creds.get("auth_token")
+    if not token:
+        return False, "auth_token required"
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                "https://api.ebay.com/commerce/taxonomy/v1_beta/category_tree/0",
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=10,
+            )
+        if resp.status_code == 200:
+            return True, None
+        return False, f"eBay responded with status {resp.status_code}"
+    except Exception as e:
+        return False, str(e)
+
+async def validate_prestashop(creds: dict) -> tuple[bool, str | None]:
+    url = creds.get("store_url")
+    api_key = creds.get("api_key")
+    if not url or not api_key:
+        return False, "store_url and api_key required"
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{url}/api/shop",
+                auth=(api_key, ""),
+                timeout=10,
+            )
+        if resp.status_code in {200, 401}:
+            return True, None
+        return False, f"PrestaShop responded with status {resp.status_code}"
+    except Exception as e:
+        return False, str(e)
+
+async def validate_cdiscount_pro(creds: dict) -> tuple[bool, str | None]:
+    api_key = creds.get("api_key")
+    if not api_key:
+        return False, "api_key required"
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                "https://api.cdiscount.com/OpenApi/json/GetSellerInformation",
+                json={"ApiKey": api_key},
+                timeout=10,
+            )
+        if resp.status_code == 200:
+            return True, None
+        return False, f"Cdiscount responded with status {resp.status_code}"
+    except Exception as e:
+        return False, str(e)
+
 validators = {
     "shopify": validate_shopify,
     "woocommerce": validate_woocommerce,
+    "ebay": validate_ebay,
+    "prestashop": validate_prestashop,
+    "cdiscount-pro": validate_cdiscount_pro,
 }
 
 @router.post("/api/connect/{platform}")

--- a/backend/tests/test_validation.py
+++ b/backend/tests/test_validation.py
@@ -1,0 +1,52 @@
+import sys
+import pathlib
+import os
+import pytest
+import httpx
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+import importlib.util
+
+connect_path = pathlib.Path(__file__).resolve().parents[1] / "api" / "connect.py"
+spec = importlib.util.spec_from_file_location("connect", connect_path)
+connect = importlib.util.module_from_spec(spec)
+os.environ.setdefault("SUPABASE_URL", "http://localhost")
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "key")
+spec.loader.exec_module(connect)  # type: ignore
+
+validate_ebay = connect.validate_ebay
+validate_prestashop = connect.validate_prestashop
+validate_cdiscount_pro = connect.validate_cdiscount_pro
+
+class MockAsyncClient:
+    def __init__(self, response: httpx.Response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def get(self, *a, **k):
+        return self._response
+
+    async def post(self, *a, **k):
+        return self._response
+
+@pytest.mark.asyncio
+async def test_validate_ebay(monkeypatch):
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: MockAsyncClient(httpx.Response(200)))
+    valid, error = await validate_ebay({"auth_token": "token"})
+    assert valid and error is None
+
+@pytest.mark.asyncio
+async def test_validate_prestashop(monkeypatch):
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: MockAsyncClient(httpx.Response(200)))
+    valid, error = await validate_prestashop({"store_url": "https://shop.example.com", "api_key": "key"})
+    assert valid and error is None
+
+@pytest.mark.asyncio
+async def test_validate_cdiscount(monkeypatch):
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: MockAsyncClient(httpx.Response(200)))
+    valid, error = await validate_cdiscount_pro({"api_key": "key"})
+    assert valid and error is None

--- a/supabase/functions/platforms/cdiscount-pro/index.ts
+++ b/supabase/functions/platforms/cdiscount-pro/index.ts
@@ -1,0 +1,58 @@
+import { serve } from "npm:@supabase/functions-js";
+import { corsHeaders } from "../../_shared/cors.ts";
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 200, headers: corsHeaders });
+  }
+  try {
+    const url = new URL(req.url);
+    const path = url.pathname.split("/").pop();
+    if (path === "products") {
+      return await handleProducts(req);
+    }
+    return await handleConnection(req);
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ success: false, error: (error as Error).message }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+});
+
+async function handleConnection(req: Request) {
+  const { apiKey } = await req.json();
+  if (!apiKey) {
+    return new Response(
+      JSON.stringify({ success: false, error: "apiKey required" }),
+      { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  return new Response(
+    JSON.stringify({ success: true, message: "Cdiscount Pro credentials valid" }),
+    { headers: { ...corsHeaders, "Content-Type": "application/json" } }
+  );
+}
+
+async function handleProducts(req: Request) {
+  const { apiKey } = await req.json();
+  if (!apiKey) {
+    return new Response(
+      JSON.stringify({ success: false, error: "apiKey required" }),
+      { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  const products = Array(5)
+    .fill(0)
+    .map((_, i) => ({
+      id: `${3000 + i}`,
+      title: `Cdiscount Product ${i + 1}`,
+      price: Math.floor(Math.random() * 60) + 15,
+    }));
+  return new Response(
+    JSON.stringify({ success: true, products }),
+    { headers: { ...corsHeaders, "Content-Type": "application/json" } }
+  );
+}

--- a/supabase/functions/platforms/ebay/index.ts
+++ b/supabase/functions/platforms/ebay/index.ts
@@ -1,0 +1,58 @@
+import { serve } from "npm:@supabase/functions-js";
+import { corsHeaders } from "../../_shared/cors.ts";
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 200, headers: corsHeaders });
+  }
+  try {
+    const url = new URL(req.url);
+    const path = url.pathname.split("/").pop();
+    if (path === "products") {
+      return await handleProducts(req);
+    }
+    return await handleConnection(req);
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ success: false, error: (error as Error).message }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+});
+
+async function handleConnection(req: Request) {
+  const { authToken } = await req.json();
+  if (!authToken) {
+    return new Response(
+      JSON.stringify({ success: false, error: "authToken required" }),
+      { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  return new Response(
+    JSON.stringify({ success: true, message: "eBay credentials valid" }),
+    { headers: { ...corsHeaders, "Content-Type": "application/json" } }
+  );
+}
+
+async function handleProducts(req: Request) {
+  const { authToken } = await req.json();
+  if (!authToken) {
+    return new Response(
+      JSON.stringify({ success: false, error: "authToken required" }),
+      { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  const products = Array(5)
+    .fill(0)
+    .map((_, i) => ({
+      id: `${1000 + i}`,
+      title: `eBay Product ${i + 1}`,
+      price: Math.floor(Math.random() * 50) + 10,
+    }));
+  return new Response(
+    JSON.stringify({ success: true, products }),
+    { headers: { ...corsHeaders, "Content-Type": "application/json" } }
+  );
+}

--- a/supabase/functions/platforms/prestashop/index.ts
+++ b/supabase/functions/platforms/prestashop/index.ts
@@ -1,0 +1,58 @@
+import { serve } from "npm:@supabase/functions-js";
+import { corsHeaders } from "../../_shared/cors.ts";
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 200, headers: corsHeaders });
+  }
+  try {
+    const url = new URL(req.url);
+    const path = url.pathname.split("/").pop();
+    if (path === "products") {
+      return await handleProducts(req);
+    }
+    return await handleConnection(req);
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ success: false, error: (error as Error).message }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+});
+
+async function handleConnection(req: Request) {
+  const { storeUrl, apiKey } = await req.json();
+  if (!storeUrl || !apiKey) {
+    return new Response(
+      JSON.stringify({ success: false, error: "storeUrl and apiKey required" }),
+      { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  return new Response(
+    JSON.stringify({ success: true, message: "PrestaShop credentials valid" }),
+    { headers: { ...corsHeaders, "Content-Type": "application/json" } }
+  );
+}
+
+async function handleProducts(req: Request) {
+  const { storeUrl, apiKey } = await req.json();
+  if (!storeUrl || !apiKey) {
+    return new Response(
+      JSON.stringify({ success: false, error: "storeUrl and apiKey required" }),
+      { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  const products = Array(5)
+    .fill(0)
+    .map((_, i) => ({
+      id: `${2000 + i}`,
+      title: `PrestaShop Product ${i + 1}`,
+      price: Math.floor(Math.random() * 70) + 5,
+    }));
+  return new Response(
+    JSON.stringify({ success: true, products }),
+    { headers: { ...corsHeaders, "Content-Type": "application/json" } }
+  );
+}


### PR DESCRIPTION
## Summary
- implement validation for eBay, PrestaShop and Cdiscount Pro in backend API
- add mock API handlers for these platforms
- test validation logic with mocked HTTP clients

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c2221025c8328a3fd63342febfd17