### PR TITLE
Add error toasts to pages

### DIFF
--- a/src/pages/AdvancedAnalytics.tsx
+++ b/src/pages/AdvancedAnalytics.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Calendar, ChevronDown, Download, BarChart3, Globe, ShoppingBag } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
 import PerformanceMetrics from '../components/analytics/PerformanceMetrics';
@@ -29,6 +30,7 @@ const AdvancedAnalytics: React.FC = () => {
       setData(mockData);
     } catch (error) {
       console.error('Error fetching analytics data:', error);
+      toast.error('Failed to load analytics data');
     } finally {
       setLoading(false);
     }

--- a/src/pages/AdvancedSuppliers.tsx
+++ b/src/pages/AdvancedSuppliers.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { 
-  Search, 
-  Filter, 
+import {
+  Search,
+  Filter,
   MapPin, 
   Star, 
   Shield, 
@@ -12,6 +12,7 @@ import {
   ArrowRight,
   Loader2
 } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { Button } from '../components/ui/button';
 
@@ -70,6 +71,7 @@ const AdvancedSuppliers: React.FC = () => {
       setFilteredSuppliers(data.suppliers);
     } catch (error) {
       console.error('Error fetching suppliers:', error);
+      toast.error('Failed to load suppliers');
     } finally {
       setLoading(false);
     }

--- a/src/pages/CustomReports.tsx
+++ b/src/pages/CustomReports.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { BarChart, Bar, LineChart, Line, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import { FileText, Download, Filter, Calendar, RefreshCw, Plus, Trash2, Settings, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { Button } from '../components/ui/button';
 
@@ -53,6 +54,7 @@ const CustomReports: React.FC = () => {
       await new Promise(resolve => setTimeout(resolve, 1500));
     } catch (error) {
       console.error('Error refreshing report:', error);
+      toast.error('Failed to refresh report');
     } finally {
       setLoading(false);
     }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { BarChart3, ShoppingBag, TrendingUp, Users, ArrowUpRight, ArrowDownRight, Package, Calendar, Bell, Settings, FileText, Bot, Database, Code, Layers, Webhook } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { supabase } from '../lib/supabase';
 import SubscriptionOverview from '../components/dashboard/SubscriptionOverview';
@@ -65,6 +66,7 @@ export default function Dashboard() {
       });
     } catch (error) {
       console.error('Erreur lors de la récupération des données du tableau de bord:', error);
+      toast.error('Failed to load dashboard data');
     } finally {
       setLoading(false);
     }

--- a/src/pages/Documentation.tsx
+++ b/src/pages/Documentation.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { FileText, Search, Book, Code, ExternalLink, ArrowLeft, ChevronRight, Copy, Check } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
 
@@ -142,7 +143,8 @@ async function importProduct(url) {
     console.log('Produit importé avec succès:', product.id);
     return product;
   } catch (error) {
-    console.error('Erreur lors de l\'importation:', error);
+    console.error("Erreur lors de l'importation:", error);
+    toast.error('Failed to import product');
   }
 }`
       }

--- a/src/pages/InternationalSelling.tsx
+++ b/src/pages/InternationalSelling.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Globe, DollarSign, Languages, Truck, Settings, Check, AlertTriangle } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
 import { Button } from '../components/ui/button';
@@ -38,6 +39,7 @@ const InternationalSelling: React.FC = () => {
       }
     } catch (error) {
       console.error('Error toggling market:', error);
+      toast.error('Failed to update market');
     } finally {
       setLoading(false);
     }

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
+import { toast } from 'sonner';
 
 import { supabase } from '../lib/supabase';
 import PricingCard from '../components/stripe/PricingCard';
@@ -29,6 +30,7 @@ const Pricing: React.FC = () => {
         }
       } catch (error) {
         console.error('Error fetching subscription:', error);
+        toast.error('Failed to fetch subscription');
       } finally {
         setLoading(false);
       }

--- a/src/pages/Success.tsx
+++ b/src/pages/Success.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { CheckCircle, Loader2 } from 'lucide-react';
 import { motion } from 'framer-motion';
+import { toast } from 'sonner';
 
 import { supabase } from '../lib/supabase';
 
@@ -37,6 +38,7 @@ const Success: React.FC = () => {
         }, 5000);
       } catch (error) {
         console.error('Error verifying session:', error);
+        toast.error('Failed to verify session');
       } finally {
         setLoading(false);
       }

--- a/src/pages/Webhooks.tsx
+++ b/src/pages/Webhooks.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Plus, Trash2, Copy, Check, RefreshCw, Loader2, AlertCircle } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { Button } from '../components/ui/button';
 
@@ -78,6 +79,7 @@ const Webhooks: React.FC = () => {
       setIsAddingWebhook(false);
     } catch (error) {
       console.error('Error adding webhook:', error);
+      toast.error('Failed to add webhook');
     } finally {
       setLoading(false);
     }
@@ -93,6 +95,7 @@ const Webhooks: React.FC = () => {
       setWebhooks(webhooks.filter(webhook => webhook.id !== id));
     } catch (error) {
       console.error('Error deleting webhook:', error);
+      toast.error('Failed to delete webhook');
     } finally {
       setLoading(false);
     }
@@ -110,6 +113,7 @@ const Webhooks: React.FC = () => {
       ));
     } catch (error) {
       console.error('Error toggling webhook:', error);
+      toast.error('Failed to update webhook');
     } finally {
       setLoading(false);
     }
@@ -125,6 +129,7 @@ const Webhooks: React.FC = () => {
       alert('Webhook test successful!');
     } catch (error) {
       console.error('Error testing webhook:', error);
+      toast.error('Webhook test failed');
       alert('Webhook test failed. Please check your URL and try again.');
     } finally {
       setLoading(false);

--- a/src/pages/WinningProducts.tsx
+++ b/src/pages/WinningProducts.tsx
@@ -11,6 +11,7 @@ import {
   ArrowUpRight,
   Loader2
 } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { Button } from '../components/ui/button';
 
@@ -81,6 +82,7 @@ const WinningProducts: React.FC = () => {
       setProducts(mockProducts);
     } catch (error) {
       console.error('Error fetching products:', error);
+      toast.error('Failed to load products');
     } finally {
       setLoading(false);
     }

--- a/src/pages/admin/Analytics.tsx
+++ b/src/pages/admin/Analytics.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { BarChart3, TrendingUp, DollarSign, Users, Calendar, Download, ArrowUpRight, ArrowDownRight } from 'lucide-react';
 import { Navigate } from 'react-router-dom';
+import { toast } from 'sonner';
 
 import { supabase } from '../../lib/supabase';
 import { useRole } from '../../context/RoleContext';
@@ -52,6 +53,7 @@ const AdminAnalytics: React.FC = () => {
       });
     } catch (error) {
       console.error('Error fetching analytics data:', error);
+      toast.error('Failed to load analytics data');
     } finally {
       setLoading(false);
     }

--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { BarChart3, Users, ShoppingBag, DollarSign, ArrowUpRight, ArrowDownRight } from 'lucide-react';
 import { Navigate } from 'react-router-dom';
+import { toast } from 'sonner';
 
 import { supabase } from '../../lib/supabase';
 import { useRole } from '../../context/RoleContext';
@@ -42,6 +43,7 @@ const AdminDashboard: React.FC = () => {
       });
     } catch (error) {
       console.error('Error fetching admin stats:', error);
+      toast.error('Failed to load dashboard stats');
     } finally {
       setDataLoading(false);
     }

--- a/src/pages/admin/Users.tsx
+++ b/src/pages/admin/Users.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Users as UsersIcon, Search, Filter, Edit, Trash, UserPlus, CheckCircle, XCircle } from 'lucide-react';
 import { Navigate } from 'react-router-dom';
+import { toast } from 'sonner';
 
 import { supabase } from '../../lib/supabase';
 import { useRole } from '../../context/RoleContext';
@@ -57,6 +58,7 @@ const UsersAdmin: React.FC = () => {
       setUsers(mockUsers);
     } catch (error) {
       console.error('Error fetching users:', error);
+      toast.error('Failed to load users');
     } finally {
       setLoading(false);
     }
@@ -82,6 +84,7 @@ const UsersAdmin: React.FC = () => {
       setUsers(users.filter(user => user.id !== userId));
     } catch (error) {
       console.error('Error deleting user:', error);
+      toast.error('Failed to delete user');
     }
   };
 
@@ -93,6 +96,7 @@ const UsersAdmin: React.FC = () => {
       ));
     } catch (error) {
       console.error('Error updating user status:', error);
+      toast.error('Failed to update user');
     }
   };
 

--- a/src/pages/auth/AuthCallback.tsx
+++ b/src/pages/auth/AuthCallback.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Loader2, CheckCircle, AlertCircle } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { supabase } from '../../lib/supabase';
 import { Button } from '../../components/ui/button';
@@ -57,6 +58,7 @@ const AuthCallback: React.FC = () => {
         }, 2000);
       } catch (error: any) {
         console.error('Auth callback error:', error);
+        toast.error('Authentication failed');
         setStatus('error');
         setErrorMessage(error.message || 'Authentication failed');
       }

--- a/src/pages/automations.tsx
+++ b/src/pages/automations.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Loader2, Zap, ArrowRight, CheckCircle } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -29,6 +30,7 @@ export default function AutomationsPage() {
       setSuccess(true);
     } catch (error) {
       console.error('Erreur lors de l\'envoi du webhook:', error);
+      toast.error("Erreur d'envoi du webhook");
       setResult('Erreur: Impossible d\'envoyer le webhook. Veuillez vérifier votre connexion et réessayer.');
     } finally {
       setLoading(false);

--- a/src/pages/blog-ai.tsx
+++ b/src/pages/blog-ai.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Loader2, Copy, Check, Download, ArrowRight } from 'lucide-react';
+import { toast } from 'sonner';
 
 import MainNavbar from '../components/layout/MainNavbar';
 import Footer from '../components/layout/Footer';
@@ -47,6 +48,7 @@ Format : Article complet en HTML simple (utilise des balises h1, h2, p, ul, li, 
       setBlogContent(content);
     } catch (error) {
       console.error("Erreur lors de la génération du blog:", error);
+      toast.error('Erreur lors de la génération du blog');
       alert("Une erreur est survenue lors de la génération du contenu. Veuillez réessayer.");
     } finally {
       setLoading(false);

--- a/src/pages/generateInvoice.tsx
+++ b/src/pages/generateInvoice.tsx
@@ -3,6 +3,7 @@ import jsPDF from 'jspdf';
 
 import 'jspdf-autotable';
 import { Loader2, Download, Plus, Trash2, FileText, Calendar, DollarSign, User, Building } from 'lucide-react';
+import { toast } from 'sonner';
 
 import MainNavbar from '../components/layout/MainNavbar';
 import Footer from '../components/layout/Footer';
@@ -147,6 +148,7 @@ export default function GenerateInvoice() {
       doc.save(`facture-${invoiceNumber}.pdf`);
     } catch (error) {
       console.error("Erreur lors de la génération du PDF:", error);
+      toast.error('Failed to generate invoice');
       alert("Une erreur est survenue lors de la génération de la facture");
     } finally {
       setLoading(false);

--- a/src/pages/seo-ai.tsx
+++ b/src/pages/seo-ai.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Loader2, Copy, Check, Download, ArrowRight } from 'lucide-react';
+import { toast } from 'sonner';
 
 import MainNavbar from '../components/layout/MainNavbar';
 import Footer from '../components/layout/Footer';
@@ -62,6 +63,7 @@ Génère un JSON SEO complet avec :
         setSeo(parsed);
       } catch (parseError) {
         console.error("Erreur de parsing JSON:", parseError);
+        toast.error('Failed to parse AI response');
         // Tentative de récupération du JSON dans la réponse
         const jsonMatch = raw.match(/```json\n([\s\S]*?)\n```/) || raw.match(/\{[\s\S]*\}/);
         if (jsonMatch) {
@@ -78,6 +80,7 @@ Génère un JSON SEO complet avec :
       }
     } catch (error) {
       console.error("Erreur IA SEO", error);
+      toast.error('Erreur IA SEO');
       alert("Erreur lors de la génération SEO. Veuillez réessayer.");
     } finally {
       setLoading(false);

--- a/src/pages/seo-competitor.tsx
+++ b/src/pages/seo-competitor.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -34,6 +35,7 @@ Retourne un JSON avec :
     } catch (error) {
       alert("Erreur lors de l'analyse SEO.");
       console.error(error);
+      toast.error("Erreur lors de l'analyse SEO");
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- notify users of API failures on many pages
- show toast when automations fail
- display toast when webhooks actions fail
- surface errors for AI tools and admin pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685c225e851c83289ba4cb874dadf1dc