### PR TITLE
Add analytics service and hook

### DIFF
--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+
+import { analyticsService, DailyImportCount, SalesAggregate, SeoScore } from '../services/analyticsService';
+
+export function useAnalytics() {
+  const [imports, setImports] = useState<DailyImportCount[]>([]);
+  const [sales, setSales] = useState<SalesAggregate[]>([]);
+  const [seoScores, setSeoScores] = useState<SeoScore[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = async () => {
+    setLoading(true);
+    try {
+      const [i, s, seo] = await Promise.all([
+        analyticsService.getDailyImportCounts(),
+        analyticsService.getSalesData(),
+        analyticsService.getSeoScores()
+      ]);
+      setImports(i);
+      setSales(s);
+      setSeoScores(seo);
+    } catch (err) {
+      console.error('Error loading analytics', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { refresh(); }, []);
+
+  return { imports, sales, seoScores, loading, refresh };
+}

--- a/src/pages/Documentation.tsx
+++ b/src/pages/Documentation.tsx
@@ -142,7 +142,7 @@ async function importProduct(url) {
     console.log('Produit importé avec succès:', product.id);
     return product;
   } catch (error) {
-    console.error('Erreur lors de l\'importation:', error);
+    console.error('Erreur lors de l'importation:', error);
   }
 }`
       }

--- a/src/pages/admin/Analytics.tsx
+++ b/src/pages/admin/Analytics.tsx
@@ -2,14 +2,14 @@ import React, { useState, useEffect } from 'react';
 import { BarChart3, TrendingUp, DollarSign, Users, Calendar, Download, ArrowUpRight, ArrowDownRight } from 'lucide-react';
 import { Navigate } from 'react-router-dom';
 
-import { supabase } from '../../lib/supabase';
 import { useRole } from '../../context/RoleContext';
+import { useAnalytics } from '../../hooks/useAnalytics';
 import { Button } from '../../components/ui/button';
 
 
 const AdminAnalytics: React.FC = () => {
   const { isAdmin, loading: roleLoading } = useRole();
-  const [loading, setLoading] = useState(true);
+  const { sales, loading: analyticsLoading, refresh } = useAnalytics();
   const [period, setPeriod] = useState('30days');
   const [stats, setStats] = useState({
     totalUsers: 0,
@@ -25,37 +25,20 @@ const AdminAnalytics: React.FC = () => {
 
   useEffect(() => {
     if (isAdmin) {
-      fetchAnalyticsData();
+      refresh();
     }
   }, [isAdmin, period]);
 
-  const fetchAnalyticsData = async () => {
-    try {
-      setLoading(true);
-      
-      // In a real app, you would fetch this data from your database
-      // For now, we'll use mock data
-      
-      // Simulate API delay
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
-      setStats({
-        totalUsers: 1234,
-        activeUsers: 789,
-        newUsers: 123,
-        revenue: 45678,
-        revenueGrowth: 8.3,
-        orders: 789,
-        ordersGrowth: 5.7,
-        averageOrderValue: 57.89,
-        conversionRate: 3.2
-      });
-    } catch (error) {
-      console.error('Error fetching analytics data:', error);
-    } finally {
-      setLoading(false);
+  useEffect(() => {
+    if (sales.length) {
+      const revenue = sales.reduce((acc, s) => acc + s.revenue, 0);
+      const orders = sales.reduce((acc, s) => acc + s.orders, 0);
+      setStats(prev => ({ ...prev, revenue, orders }));
     }
-  };
+  }, [sales]);
+
+  const loading = analyticsLoading || roleLoading;
+
 
   if (roleLoading) {
     return <div className="flex justify-center p-8">Chargement...</div>;

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -1,0 +1,106 @@
+import { supabase } from '../lib/supabase';
+
+export interface DailyImportCount {
+  date: string;
+  count: number;
+}
+
+export interface SalesAggregate {
+  date: string;
+  revenue: number;
+  orders: number;
+}
+
+export interface SeoScore {
+  id: string;
+  product_id: string;
+  score: number;
+  created_at: string;
+}
+
+export const analyticsService = {
+  async getDailyImportCounts(startDate?: string, endDate?: string): Promise<DailyImportCount[]> {
+    try {
+      const { data, error } = await supabase
+        .from('product_imports')
+        .select('id, created_at')
+        .gte('created_at', startDate || '1970-01-01')
+        .lte('created_at', endDate || new Date().toISOString());
+
+      if (error) throw error;
+
+      const counts: Record<string, number> = {};
+      (data || []).forEach((row: any) => {
+        const date = row.created_at.split('T')[0];
+        counts[date] = (counts[date] || 0) + 1;
+      });
+
+      return Object.entries(counts).map(([date, count]) => ({ date, count }));
+    } catch (error) {
+      console.error('Error fetching daily import counts:', error);
+      throw error;
+    }
+  },
+
+  async getSalesData(startDate?: string, endDate?: string): Promise<SalesAggregate[]> {
+    try {
+      const end = endDate || new Date().toISOString();
+      const start = startDate || '1970-01-01';
+
+      // Try orders table first
+      let { data, error } = await supabase
+        .from('orders')
+        .select('id, total_amount, created_at')
+        .gte('created_at', start)
+        .lte('created_at', end);
+
+      if (error && !data) {
+        // Fallback to marketplace_analytics
+        const res = await supabase
+          .from('marketplace_analytics')
+          .select('revenue, date');
+        data = res.data;
+        error = res.error;
+      }
+
+      if (error) throw error;
+
+      const aggregates: Record<string, { revenue: number; orders: number }> = {};
+
+      (data || []).forEach((row: any) => {
+        const date = (row.created_at || row.date).split('T')[0];
+        const revenue = Number(row.total_amount || row.revenue || 0);
+        if (!aggregates[date]) {
+          aggregates[date] = { revenue: 0, orders: 0 };
+        }
+        aggregates[date].revenue += revenue;
+        aggregates[date].orders += 1;
+      });
+
+      return Object.entries(aggregates).map(([date, vals]) => ({
+        date,
+        revenue: vals.revenue,
+        orders: vals.orders
+      }));
+    } catch (error) {
+      console.error('Error aggregating sales data:', error);
+      throw error;
+    }
+  },
+
+  async getSeoScores(productId?: string): Promise<SeoScore[]> {
+    try {
+      let query = supabase.from('seo_scores').select('*');
+      if (productId) {
+        query = query.eq('product_id', productId);
+      }
+
+      const { data, error } = await query;
+      if (error) throw error;
+      return data as SeoScore[];
+    } catch (error) {
+      console.error('Error fetching SEO scores:', error);
+      throw error;
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- implement `analyticsService` to query imports, orders, and SEO data
- add `useAnalytics` hook that fetches data from `analyticsService`
- connect Admin Analytics page to the new hook
- fix escape sequence in documentation example

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c226ed9d0832893b78b5c6570fe0c