### PR TITLE
Add data hooks

### DIFF
--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+
+import { supabase } from '../lib/supabase';
+import { orderService } from '../services/orderService';
+
+export interface Order {
+  id: string;
+  [key: string]: any;
+}
+
+export function useOrders() {
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchOrders = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data, error } = await supabase
+        .from('orders')
+        .select('*')
+        .order('created_at', { ascending: false });
+      if (error) throw error;
+      setOrders(data || []);
+    } catch (err: any) {
+      console.error('Error fetching orders:', err);
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchStatus = async (orderId: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const status = await orderService.getOrderStatus(orderId);
+      setOrders(prev =>
+        prev.map(o => (o.id === orderId ? { ...o, status: status.status } : o))
+      );
+      return status;
+    } catch (err: any) {
+      console.error('Error getting order status:', err);
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchOrders();
+  }, []);
+
+  return { orders, loading, error, refresh: fetchOrders, fetchStatus };
+}

--- a/src/hooks/useSEO.ts
+++ b/src/hooks/useSEO.ts
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+
+import { askChatGPT } from '../lib/openai';
+
+export interface SEOResult {
+  score: number;
+  title: string;
+  description: string;
+  recommendations: string[];
+  [key: string]: any;
+}
+
+export function useSEO() {
+  const [result, setResult] = useState<SEOResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const analyze = async (prompt: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await askChatGPT(prompt);
+      const data = JSON.parse(response);
+      setResult(data);
+      return data;
+    } catch (err: any) {
+      console.error('Error getting SEO data:', err);
+      setError(err.message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { result, loading, error, analyze };
+}

--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+
+import { supabase } from '../lib/supabase';
+
+interface Metric {
+  value: number;
+  change: number;
+}
+
+export interface Stats {
+  imports: number;
+  revenue: Metric;
+  orders: Metric;
+  visitors: Metric;
+  conversion: Metric;
+}
+
+export function useStats() {
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStats = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { count: productCount, error: productError } = await supabase
+        .from('products')
+        .select('*', { count: 'exact', head: true });
+      if (productError) throw productError;
+
+      const { data: ordersData, error: ordersError } = await supabase
+        .from('supplier_orders')
+        .select('total_amount');
+      if (ordersError) throw ordersError;
+      const orders = ordersData ? ordersData.length : 0;
+      const revenueTotal = ordersData
+        ? ordersData.reduce((sum: number, o: any) => sum + (o.total_amount || 0), 0)
+        : 0;
+
+      const { count: visitorsCount, error: visitorsError } = await supabase
+        .from('marketplace_analytics')
+        .select('*', { count: 'exact', head: true });
+      if (visitorsError) throw visitorsError;
+
+      const conversionRate = visitorsCount
+        ? Math.round(((orders / visitorsCount) * 100 + Number.EPSILON) * 100) / 100
+        : 0;
+
+      setStats({
+        imports: productCount || 0,
+        revenue: { value: revenueTotal, change: 0 },
+        orders: { value: orders, change: 0 },
+        visitors: { value: visitorsCount || 0, change: 0 },
+        conversion: { value: conversionRate, change: 0 }
+      });
+    } catch (err: any) {
+      console.error('Error fetching stats:', err);
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchStats();
+  }, []);
+
+  return { stats, loading, error, refetch: fetchStats };
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { BarChart3, ShoppingBag, TrendingUp, Users, ArrowUpRight, ArrowDownRight, Package, Calendar, Bell, Settings, FileText, Bot, Database, Code, Layers, Webhook } from 'lucide-react';
 
-import { supabase } from '../lib/supabase';
+import { useStats } from '../hooks/useStats';
 import SubscriptionOverview from '../components/dashboard/SubscriptionOverview';
 import TrackingWidget from '../components/tracking/TrackingWidget';
 import MainNavbar from '../components/layout/MainNavbar';
@@ -10,13 +10,13 @@ import Footer from '../components/layout/Footer';
 import { Button } from '../components/ui/button';
 
 export default function Dashboard() {
-  const [stats, setStats] = useState({
-    revenue: { value: 1060, change: 25 },
-    orders: { value: 98, change: 12 },
-    visitors: { value: 4521, change: 15.3 },
-    conversion: { value: 3.2, change: -0.5 }
-  });
-  const [loading, setLoading] = useState(true);
+  const { stats, loading } = useStats();
+  const metrics = stats || {
+    revenue: { value: 0, change: 0 },
+    orders: { value: 0, change: 0 },
+    visitors: { value: 0, change: 0 },
+    conversion: { value: 0, change: 0 }
+  };
   const [recentActivity, setRecentActivity] = useState([
     {
       id: 1,
@@ -44,31 +44,6 @@ export default function Dashboard() {
     }
   ]);
 
-  useEffect(() => {
-    fetchDashboardData();
-  }, []);
-
-  const fetchDashboardData = async () => {
-    try {
-      setLoading(true);
-      // Dans une application réelle, récupérez les données depuis Supabase
-      // Pour l'instant, nous utilisons des données statiques
-      
-      // Simuler un délai API
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
-      setStats({
-        revenue: { value: 1060, change: 25 },
-        orders: { value: 98, change: 12 },
-        visitors: { value: 4521, change: 15.3 },
-        conversion: { value: 3.2, change: -0.5 }
-      });
-    } catch (error) {
-      console.error('Erreur lors de la récupération des données du tableau de bord:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -84,15 +59,15 @@ export default function Dashboard() {
                 <DollarSign className="h-5 w-5 text-blue-500" />
               </div>
             </div>
-            <p className="text-2xl font-bold">{stats.revenue.value.toLocaleString()}€</p>
+            <p className="text-2xl font-bold">{metrics.revenue.value.toLocaleString()}€</p>
             <div className="flex items-center mt-2">
-              <span className={`flex items-center text-sm ${stats.revenue.change >= 0 ? 'text-green-500' : 'text-red-500'}`}>
-                {stats.revenue.change >= 0 ? (
+              <span className={`flex items-center text-sm ${metrics.revenue.change >= 0 ? 'text-green-500' : 'text-red-500'}`}>
+                {metrics.revenue.change >= 0 ? (
                   <ArrowUpRight className="h-4 w-4 mr-1" />
                 ) : (
                   <ArrowDownRight className="h-4 w-4 mr-1" />
                 )}
-                {Math.abs(stats.revenue.change)}%
+                {Math.abs(metrics.revenue.change)}%
               </span>
               <span className="text-xs text-gray-500 ml-2">vs période précédente</span>
             </div>
@@ -105,15 +80,15 @@ export default function Dashboard() {
                 <ShoppingBag className="h-5 w-5 text-purple-500" />
               </div>
             </div>
-            <p className="text-2xl font-bold">{stats.orders.value}</p>
+            <p className="text-2xl font-bold">{metrics.orders.value}</p>
             <div className="flex items-center mt-2">
-              <span className={`flex items-center text-sm ${stats.orders.change >= 0 ? 'text-green-500' : 'text-red-500'}`}>
-                {stats.orders.change >= 0 ? (
+              <span className={`flex items-center text-sm ${metrics.orders.change >= 0 ? 'text-green-500' : 'text-red-500'}`}>
+                {metrics.orders.change >= 0 ? (
                   <ArrowUpRight className="h-4 w-4 mr-1" />
                 ) : (
                   <ArrowDownRight className="h-4 w-4 mr-1" />
                 )}
-                {Math.abs(stats.orders.change)}%
+                {Math.abs(metrics.orders.change)}%
               </span>
               <span className="text-xs text-gray-500 ml-2">vs période précédente</span>
             </div>
@@ -126,15 +101,15 @@ export default function Dashboard() {
                 <Users className="h-5 w-5 text-green-500" />
               </div>
             </div>
-            <p className="text-2xl font-bold">{stats.visitors.value.toLocaleString()}</p>
+            <p className="text-2xl font-bold">{metrics.visitors.value.toLocaleString()}</p>
             <div className="flex items-center mt-2">
-              <span className={`flex items-center text-sm ${stats.visitors.change >= 0 ? 'text-green-500' : 'text-red-500'}`}>
-                {stats.visitors.change >= 0 ? (
+              <span className={`flex items-center text-sm ${metrics.visitors.change >= 0 ? 'text-green-500' : 'text-red-500'}`}>
+                {metrics.visitors.change >= 0 ? (
                   <ArrowUpRight className="h-4 w-4 mr-1" />
                 ) : (
                   <ArrowDownRight className="h-4 w-4 mr-1" />
                 )}
-                {Math.abs(stats.visitors.change)}%
+                {Math.abs(metrics.visitors.change)}%
               </span>
               <span className="text-xs text-gray-500 ml-2">vs période précédente</span>
             </div>
@@ -147,15 +122,15 @@ export default function Dashboard() {
                 <TrendingUp className="h-5 w-5 text-orange-500" />
               </div>
             </div>
-            <p className="text-2xl font-bold">{stats.conversion.value}%</p>
+            <p className="text-2xl font-bold">{metrics.conversion.value}%</p>
             <div className="flex items-center mt-2">
-              <span className={`flex items-center text-sm ${stats.conversion.change >= 0 ? 'text-green-500' : 'text-red-500'}`}>
-                {stats.conversion.change >= 0 ? (
+              <span className={`flex items-center text-sm ${metrics.conversion.change >= 0 ? 'text-green-500' : 'text-red-500'}`}>
+                {metrics.conversion.change >= 0 ? (
                   <ArrowUpRight className="h-4 w-4 mr-1" />
                 ) : (
                   <ArrowDownRight className="h-4 w-4 mr-1" />
                 )}
-                {Math.abs(stats.conversion.change)}%
+                {Math.abs(metrics.conversion.change)}%
               </span>
               <span className="text-xs text-gray-500 ml-2">vs période précédente</span>
             </div>

--- a/src/pages/Documentation.tsx
+++ b/src/pages/Documentation.tsx
@@ -142,7 +142,7 @@ async function importProduct(url) {
     console.log('Produit importé avec succès:', product.id);
     return product;
   } catch (error) {
-    console.error('Erreur lors de l\'importation:', error);
+    console.error("Erreur lors de l'importation:", error);
   }
 }`
       }

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -12,63 +12,16 @@ import {
 import { motion } from 'framer-motion';
 
 import { useShop } from '../contexts/ShopContext';
+import { useOrders } from '../hooks/useOrders';
 
-// Mock order data
-const mockOrders = [
-  {
-    id: '#2301',
-    customer: 'Michael Johnson',
-    email: 'michael.j@example.com',
-    date: '2023-06-15T14:23:54Z',
-    amount: 129.99,
-    status: 'delivered',
-    items: 2,
-  },
-  {
-    id: '#2302',
-    customer: 'Sarah Williams',
-    email: 'sarahw@example.com',
-    date: '2023-06-14T09:12:11Z',
-    amount: 89.95,
-    status: 'shipped',
-    items: 1,
-  },
-  {
-    id: '#2303',
-    customer: 'David Brown',
-    email: 'david.brown@example.com',
-    date: '2023-06-13T18:45:30Z',
-    amount: 204.50,
-    status: 'processing',
-    items: 3,
-  },
-  {
-    id: '#2304',
-    customer: 'Emily Davis',
-    email: 'edavis@example.com',
-    date: '2023-06-12T10:33:22Z',
-    amount: 59.99,
-    status: 'delivered',
-    items: 1,
-  },
-  {
-    id: '#2305',
-    customer: 'James Wilson',
-    email: 'jwilson@example.com',
-    date: '2023-06-11T15:19:45Z',
-    amount: 149.98,
-    status: 'processing',
-    items: 2,
-  },
-];
 
 const Orders: React.FC = () => {
   const { isConnected } = useShop();
-  const [orders] = useState(mockOrders);
+  const { orders, loading, error } = useOrders();
   const [searchQuery, setSearchQuery] = useState('');
 
   // Filter orders based on search query
-  const filteredOrders = orders.filter(order => 
+  const filteredOrders = orders.filter(order =>
     order.customer.toLowerCase().includes(searchQuery.toLowerCase()) ||
     order.id.toLowerCase().includes(searchQuery.toLowerCase()) ||
     order.email.toLowerCase().includes(searchQuery.toLowerCase())
@@ -123,6 +76,14 @@ const Orders: React.FC = () => {
         <p className="mt-1 text-neutral-500">Connect your store to manage orders</p>
       </div>
     );
+  }
+
+  if (loading) {
+    return <div className="p-6 text-center">Loading...</div>;
+  }
+
+  if (error) {
+    return <div className="p-6 text-center text-red-500">{error}</div>;
   }
 
   return (

--- a/src/pages/seo-competitor.tsx
+++ b/src/pages/seo-competitor.tsx
@@ -1,22 +1,18 @@
 import { useState } from 'react';
 import { Loader2 } from 'lucide-react';
 
+import { useSEO } from '../hooks/useSEO';
+
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
-import { Textarea } from '@/components/ui/textarea';
-import { askChatGPT } from '@/lib/openai';
 
 export default function SeoCompetitorPage() {
   const [url, setUrl] = useState('');
-  const [result, setResult] = useState<any>(null);
-  const [loading, setLoading] = useState(false);
+  const { result, loading, error, analyze } = useSEO();
 
   const analyzeSEO = async () => {
     if (!url.trim()) return alert("Merci d'entrer une URL valide.");
-    setLoading(true);
-    setResult(null);
-
     const prompt = `
 Analyse SEO d'une page concurrente : ${url}
 Retourne un JSON avec :
@@ -28,14 +24,9 @@ Retourne un JSON avec :
 }`;
 
     try {
-      const response = await askChatGPT(prompt);
-      const data = JSON.parse(response);
-      setResult(data);
-    } catch (error) {
+      await analyze(prompt);
+    } catch {
       alert("Erreur lors de l'analyse SEO.");
-      console.error(error);
-    } finally {
-      setLoading(false);
     }
   };
 
@@ -53,6 +44,10 @@ Retourne un JSON avec :
           {loading ? <Loader2 className="animate-spin h-4 w-4" /> : 'Analyser'}
         </Button>
       </div>
+
+      {error && (
+        <p className="text-red-500">{error}</p>
+      )}
 
       {result && (
         <Card>


### PR DESCRIPTION
## Summary
- implement `useStats`, `useOrders` and `useSEO` hooks
- fetch data from Supabase or OpenAI
- integrate hooks into Dashboard, Orders, and SEO competitor pages
- fix lint error in docs

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685c22736a488328b911cbe1dbd9eaa2