### PR TITLE
Add OpenAPI generation script and CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,3 +27,12 @@ jobs:
 
       - name: 🏗️ Build app
         run: npm run build
+
+      - name: 📖 Generate OpenAPI spec
+        run: npm run docs:api
+
+      - name: 📤 Upload OpenAPI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi
+          path: docs/openapi.json

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ shopify.app.toml
 *.orig
 *.rej
 
+
+# Python
+__pycache__/

--- a/backend/generate_openapi.py
+++ b/backend/generate_openapi.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import sys
+import json
+import os
+
+# Ensure the project root is on PYTHONPATH
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# Provide default environment variables so imports succeed
+os.environ.setdefault("SUPABASE_URL", "http://localhost")
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "key")
+os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test")
+os.environ.setdefault("STRIPE_WEBHOOK_SECRET", "whsec")
+os.environ.setdefault("STRIPE_SUCCESS_URL", "http://localhost")
+os.environ.setdefault("STRIPE_CANCEL_URL", "http://localhost")
+
+from backend.main import app
+
+
+def main() -> None:
+    """Generate OpenAPI specification."""
+    spec = app.openapi()
+    docs_dir = ROOT / "docs"
+    docs_dir.mkdir(exist_ok=True)
+    spec_path = docs_dir / "openapi.json"
+    spec_path.write_text(json.dumps(spec, indent=2))
+    print(f"OpenAPI spec written to {spec_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,149 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "FastAPI",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/api/stripe/checkout-session": {
+      "post": {
+        "summary": "Create Checkout Session",
+        "operationId": "create_checkout_session_api_stripe_checkout_session_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/stripe/webhook": {
+      "post": {
+        "summary": "Stripe Webhook",
+        "operationId": "stripe_webhook_api_stripe_webhook_post",
+        "parameters": [
+          {
+            "name": "stripe-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Stripe-Signature"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/connect/{platform}": {
+      "post": {
+        "summary": "Connect Platform",
+        "operationId": "connect_platform_api_connect__platform__post",
+        "parameters": [
+          {
+            "name": "platform",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Platform"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint src --fix"
+    "lint": "eslint src --fix",
+    "docs:api": "python backend/generate_openapi.py"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.4",


### PR DESCRIPTION
## Summary
- generate OpenAPI spec with `backend/generate_openapi.py`
- expose `docs:api` npm script
- upload generated spec in CI
- ignore Python caches

## Testing
- `npm run lint` *(fails: no-useless-escape)*
- `npm run build`
- `npm run docs:api`

------
https://chatgpt.com/codex/tasks/task_e_685c228e44e083289070052b82dbf613