### PR TITLE
Make codex_sync.sh directory aware

### DIFF
--- a/codex_sync.sh
+++ b/codex_sync.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # === CONFIGURATION ===
-REPO_DIR="/Users/admin/shopopti"
+# Use provided REPO_DIR or default to the directory of this script
+REPO_DIR="${REPO_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 LOG_FILE="$REPO_DIR/codex_sync.log"
 BRANCH=$(git -C "$REPO_DIR" rev-parse --abbrev-ref HEAD)
 DATE=$(date '+%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
## Summary
- make `codex_sync.sh` fall back to an environment variable
- keep log and git commands using the new variable

## Testing
- `bash -x codex_sync.sh > /tmp/test_root.log 2>&1`
- `cd src && bash -x ../codex_sync.sh > /tmp/test_sub.log 2>&1`

------
https://chatgpt.com/codex/tasks/task_e_685f167be7548328bf54ad9fd3288d56