### PR TITLE
Improve git command handling

### DIFF
--- a/codex_sync.sh
+++ b/codex_sync.sh
@@ -28,8 +28,12 @@ if git diff --cached --quiet; then
   log "✅ Aucun changement détecté — rien à commit."
 else
   COMMIT_MSG="🔄 Sync automatique Codex → GitHub [$DATE]"
-  git commit -m "$COMMIT_MSG"
-  log "✅ Commit effectué : $COMMIT_MSG"
+  if git commit -m "$COMMIT_MSG"; then
+    log "✅ Commit effectué : $COMMIT_MSG"
+  else
+    log "❌ Commit échoué"
+    exit 1
+  fi
 fi
 
 # === PULL avec gestion de rebase ===

--- a/codexpush
+++ b/codexpush
@@ -10,13 +10,19 @@ echo "📦 Ajout des fichiers modifiés..."
 git add .
 
 echo "📝 Création du commit : $MESSAGE_COMMIT"
-git commit -m "$MESSAGE_COMMIT"
+if ! git commit -m "$MESSAGE_COMMIT"; then
+  echo "❌ Échec du commit"
+  exit 1
+fi
 
 echo "📥 Pull des changements distants avant push..."
 git pull $REMOTE $BRANCHE --rebase
 
 echo "📤 Push vers GitHub..."
-git push $REMOTE $BRANCHE
+if ! git push $REMOTE $BRANCHE; then
+  echo "❌ Échec du push vers GitHub"
+  exit 1
+fi
 
 echo "✅ Codex → GitHub synchronisé avec succès !"
 

--- a/fix-vercel.sh
+++ b/fix-vercel.sh
@@ -17,8 +17,14 @@ fi
 
 # 3. Ajouter au git et pousser
 git add .
-git commit -m "fix: repositionner les fichiers à la racine pour Vercel"
-git push origin v6.8
+if ! git commit -m "fix: repositionner les fichiers à la racine pour Vercel"; then
+  echo "❌ Échec du commit"
+  exit 1
+fi
+if ! git push origin v6.8; then
+  echo "❌ Échec du push vers GitHub"
+  exit 1
+fi
 
 echo "✅ Push effectué. Tu peux maintenant redeployer sur Vercel."
 

--- a/push_codex_to_github.sh
+++ b/push_codex_to_github.sh
@@ -10,10 +10,16 @@ echo "📦 Ajout des fichiers modifiés..."
 git add .
 
 echo "📝 Création du commit : $MESSAGE_COMMIT"
-git commit -m "$MESSAGE_COMMIT"
+if ! git commit -m "$MESSAGE_COMMIT"; then
+  echo "❌ Échec du commit"
+  exit 1
+fi
 
 echo "📤 Push vers GitHub..."
-git push $REMOTE $BRANCHE
+if ! git push $REMOTE $BRANCHE; then
+  echo "❌ Échec du push vers GitHub"
+  exit 1
+fi
 
 echo "✅ Codex → GitHub synchronisé avec succès !"
 

--- a/pushbolt.sh
+++ b/pushbolt.sh
@@ -17,7 +17,10 @@ if [[ -n $(git status --porcelain) ]]; then
 
   if [[ "$auto_commit" == "y" ]]; then
     git add .
-    git commit -m "$MESSAGE_COMMIT"
+    if ! git commit -m "$MESSAGE_COMMIT"; then
+      echo "❌ Échec du commit"
+      exit 1
+    fi
     echo "✅ Commit automatique effectué."
   else
     echo "❌ Annulation du push. Aucun commit effectué."
@@ -33,7 +36,10 @@ git pull $REMOTE $BRANCHE --rebase
 
 # Push final
 echo "📤 Envoi vers GitHub..."
-git push $REMOTE $BRANCHE
+if ! git push $REMOTE $BRANCHE; then
+  echo "❌ Échec du push vers GitHub"
+  exit 1
+fi
 
 echo "✅ Push terminé avec succès !"
 

--- a/sync_codex_git.sh
+++ b/sync_codex_git.sh
@@ -16,11 +16,17 @@ if git diff-index --quiet HEAD --; then
   echo "✅ Aucun changement à committer."
 else
   TIMESTAMP=$(date "+%Y-%m-%d %H:%M:%S")
-  git commit -m "🚀 Sync Codex update - $TIMESTAMP"
+  if ! git commit -m "🚀 Sync Codex update - $TIMESTAMP"; then
+    echo "❌ Échec du commit"
+    exit 1
+  fi
   echo "✅ Modifications commit."
 
   git branch -M main
-  git push -u origin main
+  if ! git push -u origin main; then
+    echo "❌ Échec du push vers GitHub"
+    exit 1
+  fi
   echo "📦 Pushed to GitHub ✅"
 fi
 

--- a/sync_codex_git_v2.sh
+++ b/sync_codex_git_v2.sh
@@ -13,10 +13,16 @@ echo "📂 Ajout des fichiers modifiés..."
 git add .
 
 echo "📝 Commit avec message : $MESSAGE_COMMIT"
-git commit -m "$MESSAGE_COMMIT"
+if ! git commit -m "$MESSAGE_COMMIT"; then
+  echo "❌ Échec du commit"
+  exit 1
+fi
 
 echo "📤 Push vers GitHub..."
-git push $REMOTE $BRANCHE
+if ! git push $REMOTE $BRANCHE; then
+  echo "❌ Échec du push vers GitHub"
+  exit 1
+fi
 
 echo "✅ Codex/GitHub synchronisés avec succès !"
 


### PR DESCRIPTION
## Summary
- add error checks for `git commit` and `git push`
- surface failures with clear messages in shell scripts

## Testing
- `npm run lint` *(fails: 1 error, 476 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685f168fbea08328aa4edcd7f9ac6953