### PR TITLE
Fix TypeScript errors in order service

### DIFF
--- a/src/services/orderService.ts
+++ b/src/services/orderService.ts
@@ -19,7 +19,10 @@ export const orderService = {
       if (error) throw error;
       
       // Regrouper les articles par fournisseur
-      const itemsBySupplier = {};
+      const itemsBySupplier: Record<
+        string,
+        { product_id: string; quantity: number; price: number }[]
+      > = {};
       for (const item of order.order_items) {
         const { data: product, error: productError } = await supabase
           .from('products')
@@ -46,16 +49,21 @@ export const orderService = {
       // Transmettre la commande à chaque fournisseur
       const results = [];
       for (const [supplierId, items] of Object.entries(itemsBySupplier)) {
+        const orderItems = items as {
+          product_id: string;
+          quantity: number;
+          price: number;
+        }[];
         const result = await supplierService.createOrder(supplierId, {
           external_order_id: order.id,
           shipping_address: order.shipping_address,
-          items
+          items: orderItems
         });
         
         results.push(result);
         
         // Mettre à jour les articles de la commande avec les informations du fournisseur
-        for (const item of items) {
+        for (const item of orderItems) {
           await supabase
             .from('order_items')
             .update({


### PR DESCRIPTION
## Summary
- add a typed `itemsBySupplier` map in `forwardOrderToSupplier`
- cast items from `Object.entries` and use typed `orderItems`

## Testing
- `npm run build` *(fails: ProductData/Variant types in other files)*

------
https://chatgpt.com/codex/tasks/task_e_6861b2a2071483289ac727d3394a70d8