### PR TITLE
Centralize product variant types

### DIFF
--- a/src/services/scrapingService.ts
+++ b/src/services/scrapingService.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import * as cheerio from 'cheerio';
+import type { ProductVariant } from '../types/product';
 
 interface ScrapingOptions {
   proxy?: boolean;
@@ -7,12 +8,6 @@ interface ScrapingOptions {
   retries?: number;
 }
 
-interface ProductVariant {
-  title: string;
-  price: string;
-  sku: string;
-  stock: number;
-}
 
 interface ScrapedProduct {
   title: string;
@@ -46,13 +41,18 @@ export const scrapingService = {
       return {
         title: data.product.title,
         description: data.product.body_html,
-        price: data.product.variants[0].price,
+        price: parseFloat(data.product.variants[0].price),
         images: data.product.images.map((img: { src: string }) => img.src),
         variants: data.product.variants.map((variant: any) => ({
           title: variant.title,
-          price: variant.price,
+          price: parseFloat(variant.price),
           sku: variant.sku,
-          stock: variant.inventory_quantity
+          stock: variant.inventory_quantity,
+          options: {
+            ...(variant.option1 ? { option1: variant.option1 } : {}),
+            ...(variant.option2 ? { option2: variant.option2 } : {}),
+            ...(variant.option3 ? { option3: variant.option3 } : {})
+          }
         })),
         metadata: {
           source: 'shopify',

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -1,0 +1,43 @@
+export interface ProductVariant {
+  id?: string;
+  title: string;
+  price: number;
+  sku?: string;
+  stock?: number;
+  options: Record<string, string>;
+}
+
+export interface ProductData {
+  id?: string;
+  title: string;
+  description: string;
+  price: number;
+  images: string[];
+  variants?: ProductVariant[];
+  sku?: string;
+  stock?: number;
+  category?: string;
+  weight?: number;
+  dimensions?: {
+    length: number;
+    width: number;
+    height: number;
+  };
+  metadata?: Record<string, any>;
+  seo?: {
+    title: string;
+    description: string;
+    keywords: string[];
+  };
+  reviews?: ProductReview[];
+}
+
+export interface ProductReview {
+  id?: string;
+  rating: number;
+  comment: string;
+  author: string;
+  date: string;
+  verified: boolean;
+  helpful?: number;
+}

--- a/src/types/supplier.ts
+++ b/src/types/supplier.ts
@@ -11,6 +11,8 @@ export interface ExternalSupplier {
   user_id: string;
 }
 
+import type { ProductVariant } from './product';
+
 export interface SupplierProduct {
   id: string;
   externalId: string;
@@ -37,18 +39,6 @@ export interface SupplierProduct {
   metadata?: Record<string, any>;
 }
 
-export interface ProductVariant {
-  id: string;
-  name: string;
-  sku?: string;
-  price: number;
-  stock: number;
-  attributes: {
-    name: string;
-    value: string;
-  }[];
-  image?: string;
-}
 
 export interface SupplierCategory {
   id: string;


### PR DESCRIPTION
## Summary
- introduce `src/types/product.ts` for shared interfaces
- remove in-file interfaces in `importService.ts`
- use centralized `ProductVariant` in supplier and scraping services
- parse numeric prices when scraping Shopify
- default generated variants to include a price value
- tighten a few typings

## Testing
- `npm run build` *(fails: cannot find some modules and implicit any errors)*

------
https://chatgpt.com/codex/tasks/task_e_6861b29d65dc832887a3d1811b6da595