### PR TITLE
Centralize product types

### DIFF
--- a/src/services/importService.ts
+++ b/src/services/importService.ts
@@ -7,50 +7,11 @@ import { supabase } from '../lib/supabase';
 
 import { aiService } from './aiService';
 import { supplierService } from './supplierService';
-
-export interface ProductData {
-  id?: string;
-  title: string;
-  description: string;
-  price: number;
-  images: string[];
-  variants?: ProductVariant[];
-  sku?: string;
-  stock?: number;
-  category?: string;
-  weight?: number;
-  dimensions?: {
-    length: number;
-    width: number;
-    height: number;
-  };
-  metadata?: Record<string, any>;
-  seo?: {
-    title: string;
-    description: string;
-    keywords: string[];
-  };
-  reviews?: ProductReview[];
-}
-
-interface ProductVariant {
-  id?: string;
-  title: string;
-  price: number;
-  sku?: string;
-  stock?: number;
-  options: Record<string, string>;
-}
-
-interface ProductReview {
-  id?: string;
-  rating: number;
-  comment: string;
-  author: string;
-  date: string;
-  verified: boolean;
-  helpful?: number;
-}
+import {
+  ProductData,
+  ProductVariant,
+  ProductReview
+} from '../types/product';
 
 // Updated list of reliable CORS proxies
 const CORS_PROXIES = [
@@ -425,13 +386,15 @@ export const importService = {
         features: []
       });
 
-      let finalVariants = variants.length > 0 ? variants : undefined;
+      let finalVariants: ProductVariant[] | undefined =
+        variants.length > 0 ? variants : undefined;
       if (!finalVariants) {
-        finalVariants = await aiService.generateVariants({
+        const generated = await aiService.generateVariants({
           title: optimizedTitle,
           description: optimizedDescription,
           category: 'Amazon'
         });
+        finalVariants = generated.map(v => ({ ...v, price }));
       }
 
       const reviews = $('.review')
@@ -586,15 +549,16 @@ export const importService = {
       
       // Transformer les produits au format Shopopti+
       const transformedProducts = await Promise.all(
-        products.map(async product => {
-          let variants = product.variants;
-          if (!variants || variants.length === 0) {
-            variants = await aiService.generateVariants({
-              title: product.name,
-              description: product.description,
-              category: product.category
-            });
-          }
+          products.map(async product => {
+            let variants: ProductVariant[] | undefined = product.variants;
+            if (!variants || variants.length === 0) {
+              const generated = await aiService.generateVariants({
+                title: product.name,
+                description: product.description,
+                category: product.category
+              });
+              variants = generated.map(v => ({ ...v, price: product.price }));
+            }
           return {
             title: product.name,
             description: product.description,

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -1,0 +1,43 @@
+export interface ProductVariant {
+  id?: string;
+  title: string;
+  price: number;
+  sku?: string;
+  stock?: number;
+  options: Record<string, string>;
+}
+
+export interface ProductData {
+  id?: string;
+  title: string;
+  description: string;
+  price: number;
+  images: string[];
+  variants?: ProductVariant[];
+  sku?: string;
+  stock?: number;
+  category?: string;
+  weight?: number;
+  dimensions?: {
+    length: number;
+    width: number;
+    height: number;
+  };
+  metadata?: Record<string, any>;
+  seo?: {
+    title: string;
+    description: string;
+    keywords: string[];
+  };
+  reviews?: ProductReview[];
+}
+
+export interface ProductReview {
+  id?: string;
+  rating: number;
+  comment: string;
+  author: string;
+  date: string;
+  verified: boolean;
+  helpful?: number;
+}

--- a/src/types/supplier.ts
+++ b/src/types/supplier.ts
@@ -1,3 +1,5 @@
+import { ProductVariant } from './product';
+
 export interface ExternalSupplier {
   id: string;
   name: string;
@@ -35,19 +37,6 @@ export interface SupplierProduct {
   shipping_time?: string;
   processing_time?: string;
   metadata?: Record<string, any>;
-}
-
-export interface ProductVariant {
-  id: string;
-  name: string;
-  sku?: string;
-  price: number;
-  stock: number;
-  attributes: {
-    name: string;
-    value: string;
-  }[];
-  image?: string;
 }
 
 export interface SupplierCategory {


### PR DESCRIPTION
## Summary
- add `ProductVariant`, `ProductData`, and `ProductReview` interfaces
- use shared product types in `importService`
- reference shared `ProductVariant` type from supplier definitions
- handle AI‑generated variants without price

## Testing
- `npm run build` *(fails: Cannot find module '@/lib/openai' and other unrelated type errors)*

------
https://chatgpt.com/codex/tasks/task_e_686521b4b6448328bbbcdc240b179c46