### PR TITLE
Update README setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@
 - Normalisation des scripts shell (ex: `fix-vercel.sh`)
 - Préparation pour la branche `v6.9` (Analytics, Stripe Billing, Assistant AI...)
 
+### 🛠 Installation
+
+Avant d'exécuter les commandes de build ou de lint, installez d'abord les dépendances :
+
+```bash
+npm ci  # ou npm install
+```
+
+### 🧪 Tests
+
+Dans les environnements CI, utilisez `vitest --run` pour éviter le mode watch :
+
+```bash
+npm run test -- --run
+```
+
 ---
 
 ### 🚀 Étapes suivantes


### PR DESCRIPTION
## Summary
- document that dependencies must be installed before building or linting
- recommend `vitest --run` for CI

## Testing
- `npm run test -- --run`
- `npm run build` *(fails: type errors)*
- `npm run lint` *(fails: eslint config issue)*

------
https://chatgpt.com/codex/tasks/task_e_686558016864832888487a0ce8df2a9b