### PR TITLE
Remove hardcoded Supabase keys

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,4 +14,4 @@
     X-XSS-Protection = "1; mode=block"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
-    Content-Security-Policy = "default-src 'self'; connect-src 'self' https://lyxpzzskjflqdzzkffyz.supabase.co https://api.openai.com; img-src 'self' data: https://images.pexels.com https://upload.wikimedia.org; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' 'unsafe-inline' 'unsafe-eval';"
+    Content-Security-Policy = "default-src 'self'; connect-src 'self' https://yourproject.supabase.co https://api.openai.com; img-src 'self' data: https://images.pexels.com https://upload.wikimedia.org; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' 'unsafe-inline' 'unsafe-eval';"

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,8 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 
-// Utilisation de valeurs par défaut pour le développement local
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || 'https://lyxpzzskjflqdzzkffyz.supabase.co';
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imx5eHB6enNramZscWR6emtmZnl6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDYyNzY2MzEsImV4cCI6MjA2MTg1MjYzMX0.pRVL8_yDwok4RB9vL1PpR6KxgWaJnMJtlodXTvYTB7g';
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {


### PR DESCRIPTION
## Summary
- use environment placeholders for the Supabase client
- update CSP in `netlify.toml` to use placeholder URL

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6865580de394832897b7db34737cee14