### PR TITLE
Configure path alias & update imports

### DIFF
--- a/src/components/ChatbotWidget.tsx
+++ b/src/components/ChatbotWidget.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { Send, MessageCircle, X, User, Bot, Loader2 } from 'lucide-react';
 import { AnimatePresence, motion } from 'framer-motion';
 
-import { useChatbot } from "../hooks/useChatbot";
+import { useChatbot } from "@/hooks/useChatbot";
 
 export default function ChatbotWidget() {
   const [open, setOpen] = useState(false);

--- a/src/components/ai/AiAssistant.tsx
+++ b/src/components/ai/AiAssistant.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Send, Bot, User, Sparkles, Copy, Check, Loader2 } from 'lucide-react';
 
-import { Button } from '../ui/button';
+import { Button } from '@/components/ui/button';
 
 interface Message {
   role: 'user' | 'assistant';

--- a/src/components/ai/CompetitorAnalysis.tsx
+++ b/src/components/ai/CompetitorAnalysis.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Search, Loader2, ExternalLink, BarChart, TrendingUp, DollarSign, Eye } from 'lucide-react';
 
-import { Button } from '../ui/button';
+import { Button } from '@/components/ui/button';
 
 interface CompetitorAnalysisProps {
   onAnalysisComplete?: (data: any) => void;

--- a/src/components/ai/ProductOptimizer.tsx
+++ b/src/components/ai/ProductOptimizer.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Sparkles, Check, Loader2, RefreshCw, ArrowRight } from 'lucide-react';
 
-import { Button } from '../ui/button';
+import { Button } from '@/components/ui/button';
 
 interface ProductOptimizerProps {
   product: {

--- a/src/components/analytics/ProductPerformance.tsx
+++ b/src/components/analytics/ProductPerformance.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import { ArrowUpRight, ArrowDownRight, Search, Filter } from 'lucide-react';
 
-import { Button } from '../ui/button';
+import { Button } from '@/components/ui/button';
 
 interface Product {
   id: string;

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -10,8 +10,8 @@ import {
   Loader2
 } from 'lucide-react';
 
-import { supabase } from '../../lib/supabase';
-import { Button } from '../ui/button';
+import { supabase } from '@/lib/supabase';
+import { Button } from '@/components/ui/button';
 
 import SocialLoginButtons from './SocialLoginButtons';
 import MfaOtpForm from './MfaOtpForm';

--- a/src/components/auth/MfaEnroll.tsx
+++ b/src/components/auth/MfaEnroll.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { Loader2 } from 'lucide-react';
 
-import { supabase } from '../../lib/supabase';
-import { Button } from '../ui/button';
-import { Input } from '../ui/input';
+import { supabase } from '@/lib/supabase';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 
 interface EnrollResult {
   id: string;

--- a/src/components/auth/MfaOtpForm.tsx
+++ b/src/components/auth/MfaOtpForm.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { Loader2 } from 'lucide-react';
 
-import { supabase } from '../../lib/supabase';
-import { Button } from '../ui/button';
-import { Input } from '../ui/input';
+import { supabase } from '@/lib/supabase';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 
 interface MfaOtpFormProps {
   factorId: string;

--- a/src/components/auth/MfaSettings.tsx
+++ b/src/components/auth/MfaSettings.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
-import { supabase } from '../../lib/supabase';
-import { Button } from '../ui/button';
+import { supabase } from '@/lib/supabase';
+import { Button } from '@/components/ui/button';
 
 import MfaEnroll from './MfaEnroll';
 

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, useEffect, useState } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { Loader2 } from 'lucide-react';
 
-import { supabase } from '../../lib/supabase';
+import { supabase } from '@/lib/supabase';
 
 interface ProtectedRouteProps {
   children: ReactNode;

--- a/src/components/auth/RegisterForm.tsx
+++ b/src/components/auth/RegisterForm.tsx
@@ -11,8 +11,8 @@ import {
   Loader2
 } from 'lucide-react';
 
-import { supabase } from '../../lib/supabase';
-import { Button } from '../ui/button';
+import { supabase } from '@/lib/supabase';
+import { Button } from '@/components/ui/button';
 
 import SocialLoginButtons from './SocialLoginButtons';
 import MfaEnroll from './MfaEnroll';

--- a/src/components/auth/SocialLoginButtons.tsx
+++ b/src/components/auth/SocialLoginButtons.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { toast } from 'sonner';
 import { Loader2 } from 'lucide-react';
 
-import { supabase } from '../../lib/supabase';
+import { supabase } from '@/lib/supabase';
 
 interface SocialLoginButtonsProps {
   onLoginStart?: () => void;

--- a/src/components/automation/BulkActions.tsx
+++ b/src/components/automation/BulkActions.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Check, ChevronDown, Loader2 } from 'lucide-react';
 
-import { Button } from '../ui/button';
+import { Button } from '@/components/ui/button';
 
 interface BulkActionsProps {
   selectedCount: number;

--- a/src/components/dashboard/SubscriptionOverview.tsx
+++ b/src/components/dashboard/SubscriptionOverview.tsx
@@ -2,10 +2,10 @@ import React, { useEffect, useState } from 'react';
 import { Zap, Calendar, Loader2 } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
-import { supabase } from '../../lib/supabase';
-import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
-import { Badge } from '../ui/badge';
-import { Button } from '../ui/button';
+import { supabase } from '@/lib/supabase';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 
 const SubscriptionOverview: React.FC = () => {
   const [subscription, setSubscription] = useState<any>(null);

--- a/src/components/dropshipping/OrderFulfillment.tsx
+++ b/src/components/dropshipping/OrderFulfillment.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { Package, Truck, CheckCircle, AlertTriangle, Search, Filter, ArrowRight, Printer, Download } from 'lucide-react';
 
-import { Button } from '../ui/button';
-import { Badge } from '../ui/badge';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 
 interface Order {
   id: string;

--- a/src/components/dropshipping/ProductFinder.tsx
+++ b/src/components/dropshipping/ProductFinder.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Search, Filter, TrendingUp, DollarSign, Star, ShoppingBag, Truck, Tag, ArrowUpRight } from 'lucide-react';
 
-import { Button } from '../ui/button';
+import { Button } from '@/components/ui/button';
 
 interface Product {
   id: string;

--- a/src/components/dropshipping/SupplierDirectory.tsx
+++ b/src/components/dropshipping/SupplierDirectory.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { Search, Filter, MapPin, Star, Globe, TrendingUp, Check, ExternalLink } from 'lucide-react';
 
-import { Button } from '../ui/button';
-import { supabase } from '../../lib/supabase';
+import { Button } from '@/components/ui/button';
+import { supabase } from '@/lib/supabase';
 
 interface Supplier {
   id: string;

--- a/src/components/import/CSVImporter.tsx
+++ b/src/components/import/CSVImporter.tsx
@@ -3,7 +3,7 @@ import { useDropzone } from 'react-dropzone';
 import { Upload, AlertCircle, FileSpreadsheet, Loader2 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 
-import { importService } from '../../services/importService';
+import { importService } from '@/services/importService';
 
 interface CSVImporterProps {
   marketplace?: string;

--- a/src/components/import/SupplierCatalogImporter.tsx
+++ b/src/components/import/SupplierCatalogImporter.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { Search, Filter, Tag, DollarSign, Truck, Star, ShoppingBag } from 'lucide-react';
 
-import { supabase } from '../../lib/supabase';
-import { Button } from '../ui/button';
+import { supabase } from '@/lib/supabase';
+import { Button } from '@/components/ui/button';
 
 interface Supplier {
   id: string;

--- a/src/components/import/URLImporter.tsx
+++ b/src/components/import/URLImporter.tsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 import { Link as LinkIcon, AlertCircle, ArrowRight, Loader2, Star } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 
-import { importService } from '../../services/importService';
-import { scrapingService } from '../../services/scrapingService';
+import { importService } from '@/services/importService';
+import { scrapingService } from '@/services/scrapingService';
 
 interface URLImporterProps {
   marketplace?: string;

--- a/src/components/integrations/ApiIntegration.tsx
+++ b/src/components/integrations/ApiIntegration.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Code, Key, Lock, Save, Loader2, CheckCircle, AlertCircle } from 'lucide-react';
 
-import { Button } from '../ui/button';
+import { Button } from '@/components/ui/button';
 
 interface ApiIntegrationProps {
   onSave?: (credentials: ApiCredentials) => Promise<void>;

--- a/src/components/integrations/CategoryMapping.tsx
+++ b/src/components/integrations/CategoryMapping.tsx
@@ -8,7 +8,7 @@ import {
   RefreshCw
 } from 'lucide-react';
 
-import { Button } from '../ui/button';
+import { Button } from '@/components/ui/button';
 
 interface CategoryMappingProps {
   platforms: {

--- a/src/components/integrations/DataMappingConfig.tsx
+++ b/src/components/integrations/DataMappingConfig.tsx
@@ -9,7 +9,7 @@ import {
   ArrowDown
 } from 'lucide-react';
 
-import { Button } from '../ui/button';
+import { Button } from '@/components/ui/button';
 
 interface DataMappingConfigProps {
   onSaveMapping: (mapping: DataMapping[]) => Promise<void>;

--- a/src/components/integrations/IntegrationCard.tsx
+++ b/src/components/integrations/IntegrationCard.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { ExternalLink, Check, X, Settings, Loader2 } from 'lucide-react';
 
-import { Button } from '../ui/button';
+import { Button } from '@/components/ui/button';
 
 interface IntegrationCardProps {
   integration: {

--- a/src/components/integrations/NotificationSettings.tsx
+++ b/src/components/integrations/NotificationSettings.tsx
@@ -10,7 +10,7 @@ import {
   AlertTriangle
 } from 'lucide-react';
 
-import { Button } from '../ui/button';
+import { Button } from '@/components/ui/button';
 
 interface NotificationSettingsProps {
   onSaveSettings: (settings: NotificationSettings) => Promise<void>;

--- a/src/components/integrations/PlatformConnector.tsx
+++ b/src/components/integrations/PlatformConnector.tsx
@@ -12,8 +12,8 @@ import {
   Link as LinkIcon
 } from 'lucide-react';
 
-import { Button } from '../ui/button';
-import { Input } from '../ui/input';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 
 interface PlatformConnectorProps {
   platform: {

--- a/src/components/integrations/PlatformStatus.tsx
+++ b/src/components/integrations/PlatformStatus.tsx
@@ -9,7 +9,7 @@ import {
   ArrowDownRight
 } from 'lucide-react';
 
-import { Button } from '../ui/button';
+import { Button } from '@/components/ui/button';
 
 interface PlatformStatusProps {
   platforms: {

--- a/src/components/integrations/SyncHistory.tsx
+++ b/src/components/integrations/SyncHistory.tsx
@@ -11,7 +11,7 @@ import {
   Filter
 } from 'lucide-react';
 
-import { Button } from '../ui/button';
+import { Button } from '@/components/ui/button';
 
 interface SyncHistoryProps {
   onRefresh: () => Promise<void>;

--- a/src/components/integrations/SyncSettings.tsx
+++ b/src/components/integrations/SyncSettings.tsx
@@ -10,7 +10,7 @@ import {
   Loader2
 } from 'lucide-react';
 
-import { Button } from '../ui/button';
+import { Button } from '@/components/ui/button';
 
 interface SyncSettingsProps {
   platforms: {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,9 +3,9 @@ import { Menu, Bell, ChevronDown, Search, Settings, LogOut, CreditCard, User, He
 import { useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 
-import { supabase } from '../../lib/supabase';
-import { Button } from '../ui/button';
-import LanguageSelector from '../LanguageSelector';
+import { supabase } from '@/lib/supabase';
+import { Button } from '@/components/ui/button';
+import LanguageSelector from '@/components/LanguageSelector';
 
 import Logo from './Logo';
 

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Outlet } from 'react-router-dom';
 import { motion } from 'framer-motion';
 
-import ChatbotWidget from '../ChatbotWidget';
+import ChatbotWidget from '@/components/ChatbotWidget';
 
 import Sidebar from './Sidebar';
 import Header from './Header';

--- a/src/components/layout/MainNavbar.tsx
+++ b/src/components/layout/MainNavbar.tsx
@@ -24,9 +24,9 @@ import {
   X
 } from 'lucide-react';
 
-import { Button } from '../ui/button';
-import LoginModal from '../auth/LoginModal';
-import { supabase } from '../../lib/supabase';
+import { Button } from '@/components/ui/button';
+import LoginModal from '@/components/auth/LoginModal';
+import { supabase } from '@/lib/supabase';
 
 import Logo from './Logo';
 

--- a/src/components/marketplace/MarketplaceCard.tsx
+++ b/src/components/marketplace/MarketplaceCard.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { ExternalLink, Check, Globe, DollarSign, AlertTriangle, Loader2 } from 'lucide-react';
 
-import { Button } from '../ui/button';
+import { Button } from '@/components/ui/button';
 
 interface MarketplaceCardProps {
   marketplace: {

--- a/src/components/multichannel/ChannelManager.tsx
+++ b/src/components/multichannel/ChannelManager.tsx
@@ -12,7 +12,7 @@ import {
   X
 } from 'lucide-react';
 
-import { Button } from '../ui/button';
+import { Button } from '@/components/ui/button';
 
 interface Channel {
   id: string;

--- a/src/components/multichannel/ProductPublisher.tsx
+++ b/src/components/multichannel/ProductPublisher.tsx
@@ -10,7 +10,7 @@ import {
   Loader2
 } from 'lucide-react';
 
-import { Button } from '../ui/button';
+import { Button } from '@/components/ui/button';
 
 interface Product {
   id: string;

--- a/src/components/stripe/CheckoutButton.tsx
+++ b/src/components/stripe/CheckoutButton.tsx
@@ -3,8 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import { Loader2 } from 'lucide-react';
 
-import { createCheckoutSession } from '../../lib/stripe';
-import { supabase } from '../../lib/supabase';
+import { createCheckoutSession } from '@/lib/stripe';
+import { supabase } from '@/lib/supabase';
 
 interface CheckoutButtonProps {
   priceId: string;

--- a/src/components/stripe/SubscriptionBanner.tsx
+++ b/src/components/stripe/SubscriptionBanner.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Sparkles, X } from 'lucide-react';
 
-import { supabase } from '../../lib/supabase';
+import { supabase } from '@/lib/supabase';
 
 const SubscriptionBanner: React.FC = () => {
   const [subscription, setSubscription] = useState<any>(null);

--- a/src/components/stripe/SubscriptionStatus.tsx
+++ b/src/components/stripe/SubscriptionStatus.tsx
@@ -3,9 +3,9 @@ import { Loader2, CreditCard, Calendar, AlertTriangle, CheckCircle } from 'lucid
 import { toast } from 'sonner';
 import { Link } from 'react-router-dom';
 
-import { supabase } from '../../lib/supabase';
-import { Button } from '../../components/ui/button';
-import { Badge } from '../../components/ui/badge';
+import { supabase } from '@/lib/supabase';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 
 const SubscriptionStatus: React.FC = () => {
   const [subscription, setSubscription] = useState<any>(null);

--- a/src/components/tracking/RecentTrackings.tsx
+++ b/src/components/tracking/RecentTrackings.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Package, ExternalLink } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
-import { trackingService } from '../../services/trackingService';
+import { trackingService } from '@/services/trackingService';
 
 import PackageStatusBadge from './PackageStatusBadge';
 

--- a/src/components/tracking/TrackingHistory.tsx
+++ b/src/components/tracking/TrackingHistory.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Package, Truck, CheckCircle, AlertCircle } from 'lucide-react';
 
-import { TrackingEvent, TrackingResult } from '../../services/trackingService';
+import { TrackingEvent, TrackingResult } from '@/services/trackingService';
 
 interface TrackingHistoryProps {
   result: TrackingResult;

--- a/src/components/tracking/TrackingResult.tsx
+++ b/src/components/tracking/TrackingResult.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Printer, Phone } from 'lucide-react';
 
-import { TrackingResult as TrackingResultType } from '../../services/trackingService';
+import { TrackingResult as TrackingResultType } from '@/services/trackingService';
 
 import TrackingHistory from './TrackingHistory';
 import PackageStatusBadge from './PackageStatusBadge';

--- a/src/components/tracking/TrackingWidget.tsx
+++ b/src/components/tracking/TrackingWidget.tsx
@@ -3,7 +3,7 @@ import { Package, Search } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
-import { useTracking } from '../../hooks/useTracking';
+import { useTracking } from '@/hooks/useTracking';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';

--- a/src/context/RoleContext.tsx
+++ b/src/context/RoleContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState, ReactNode, useEffect } from 'react';
 
-import { supabase } from '../lib/supabase';
+import { supabase } from '@/lib/supabase';
 
 // Define user roles
 export type UserRole = 'user' | 'admin' | 'superadmin';

--- a/src/contexts/CurrencyContext.tsx
+++ b/src/contexts/CurrencyContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState, ReactNode, useEffect } from 'react';
 
-import { supabase } from '../lib/supabase';
+import { supabase } from '@/lib/supabase';
 
 export const availableCurrencies = [
   'USD',

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useState, ReactNode, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { supabase } from '../lib/supabase';
+import { supabase } from '@/lib/supabase';
 
 export const availableLanguages = [
   { code: 'fr', name: 'Français', flag: '🇫🇷' },

--- a/src/contexts/ShopContext.tsx
+++ b/src/contexts/ShopContext.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useState, ReactNode, useEffect } from 'react
 import { toast } from 'sonner';
 import axios from 'axios';
 
-import { supabase } from '../lib/supabase';
+import { supabase } from '@/lib/supabase';
 
 type StoreType = 'shopify' | 'woocommerce' | 'etsy' | 'amazon' | 'tiktok';
 

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useState, ReactNode, useEffect } from 'react';
 import { User, Session } from '@supabase/supabase-js';
 
-import { supabase } from '../lib/supabase';
+import { supabase } from '@/lib/supabase';
 
 interface UserContextType {
   user: User | null;

--- a/src/hooks/useChatbot.ts
+++ b/src/hooks/useChatbot.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { askChatGPT } from "../lib/openai";
+import { askChatGPT } from "@/lib/openai";
 
 export function useChatbot() {
   const [messages, setMessages] = useState<{ role: string; content: string }[]>([]);

--- a/src/hooks/useTracking.ts
+++ b/src/hooks/useTracking.ts
@@ -1,7 +1,7 @@
 import { useState, useTransition } from 'react';
 import { toast } from 'sonner';
 
-import { trackingService, TrackingResult } from '../services/trackingService';
+import { trackingService, TrackingResult } from '@/services/trackingService';
 
 export function useTracking() {
   const [trackingNumber, setTrackingNumber] = useState('');

--- a/src/modules/ab-testing/index.ts
+++ b/src/modules/ab-testing/index.ts
@@ -1,4 +1,4 @@
-import { supabase } from '../../lib/supabase';
+import { supabase } from '@/lib/supabase';
 
 export interface ABTest {
   id?: string;

--- a/src/modules/accounting/index.ts
+++ b/src/modules/accounting/index.ts
@@ -2,7 +2,7 @@ import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import { utils, writeFile } from 'xlsx';
 
-import { supabase } from '../../lib/supabase';
+import { supabase } from '@/lib/supabase';
 
 export interface Invoice {
   id?: string;

--- a/src/modules/ai/hooks/useAiAssistant.ts
+++ b/src/modules/ai/hooks/useAiAssistant.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { aiService } from '../../../services/aiService';
+import { aiService } from '@/services/aiService';
 
 export interface AiAssistantMessage {
   role: 'user' | 'assistant';

--- a/src/modules/ai/hooks/useAiOptimization.ts
+++ b/src/modules/ai/hooks/useAiOptimization.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { aiService } from '../../../services/aiService';
+import { aiService } from '@/services/aiService';
 
 export interface OptimizationOptions {
   title?: boolean;

--- a/src/modules/ai/index.ts
+++ b/src/modules/ai/index.ts
@@ -1,7 +1,7 @@
 // AI Module Index
 // This file exports all AI-related functionality from a central location
 
-import { aiService } from '../../services/aiService';
+import { aiService } from '@/services/aiService';
 
 // Re-export the AI service
 export { aiService };

--- a/src/modules/chat/index.ts
+++ b/src/modules/chat/index.ts
@@ -1,5 +1,5 @@
-import { supabase } from '../../lib/supabase';
-import { aiService } from '../ai';
+import { supabase } from '@/lib/supabase';
+import { aiService } from '@/modules/ai';
 
 export interface ChatMessage {
   id?: string;

--- a/src/modules/funnels/index.ts
+++ b/src/modules/funnels/index.ts
@@ -1,4 +1,4 @@
-import { supabase } from '../../lib/supabase';
+import { supabase } from '@/lib/supabase';
 
 export interface Funnel {
   id?: string;

--- a/src/modules/inventory/index.ts
+++ b/src/modules/inventory/index.ts
@@ -1,4 +1,4 @@
-import { supabase } from '../../lib/supabase';
+import { supabase } from '@/lib/supabase';
 
 export interface StockAlert {
   id?: string;

--- a/src/modules/repricing/index.ts
+++ b/src/modules/repricing/index.ts
@@ -1,5 +1,5 @@
-import { supabase } from '../../lib/supabase';
-import { aiService } from '../ai';
+import { supabase } from '@/lib/supabase';
+import { aiService } from '@/modules/ai';
 
 export interface PricingRule {
   id?: string;

--- a/src/modules/returns/index.ts
+++ b/src/modules/returns/index.ts
@@ -1,4 +1,4 @@
-import { supabase } from '../../lib/supabase';
+import { supabase } from '@/lib/supabase';
 
 export interface ReturnRequest {
   id?: string;

--- a/src/modules/templates/index.ts
+++ b/src/modules/templates/index.ts
@@ -1,5 +1,5 @@
-import { supabase } from '../../lib/supabase';
-import { aiService } from '../ai';
+import { supabase } from '@/lib/supabase';
+import { aiService } from '@/modules/ai';
 
 export interface Template {
   id?: string;

--- a/src/pages/Account/Subscription.tsx
+++ b/src/pages/Account/Subscription.tsx
@@ -3,10 +3,10 @@ import { Loader2, CreditCard, Calendar, AlertTriangle, CheckCircle, ArrowLeft } 
 import { toast } from 'sonner';
 import { Link } from 'react-router-dom';
 
-import { supabase } from '../../lib/supabase';
-import { Button } from '../../components/ui/button';
-import { Badge } from '../../components/ui/badge';
-import SubscriptionStatus from '../../components/stripe/SubscriptionStatus';
+import { supabase } from '@/lib/supabase';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import SubscriptionStatus from '@/components/stripe/SubscriptionStatus';
 
 const Subscription: React.FC = () => {
   return (

--- a/src/pages/AdvancedAnalytics.tsx
+++ b/src/pages/AdvancedAnalytics.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { Calendar, ChevronDown, Download, BarChart3, Globe, ShoppingBag } from 'lucide-react';
 
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
-import PerformanceMetrics from '../components/analytics/PerformanceMetrics';
-import TrafficSources from '../components/analytics/TrafficSources';
-import ProductPerformance from '../components/analytics/ProductPerformance';
-import { Button } from '../components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import PerformanceMetrics from '@/components/analytics/PerformanceMetrics';
+import TrafficSources from '@/components/analytics/TrafficSources';
+import ProductPerformance from '@/components/analytics/ProductPerformance';
+import { Button } from '@/components/ui/button';
 
 const AdvancedAnalytics: React.FC = () => {
   const [activeTab, setActiveTab] = useState('overview');

--- a/src/pages/AdvancedSuppliers.tsx
+++ b/src/pages/AdvancedSuppliers.tsx
@@ -13,7 +13,7 @@ import {
   Loader2
 } from 'lucide-react';
 
-import { Button } from '../components/ui/button';
+import { Button } from '@/components/ui/button';
 
 interface Supplier {
   id: string;

--- a/src/pages/AiHub.tsx
+++ b/src/pages/AiHub.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
 import { Sparkles, Bot, Search, TrendingUp, FileText } from 'lucide-react';
 
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
-import { Button } from '../components/ui/button';
-import ProductOptimizer from '../components/ai/ProductOptimizer';
-import AiAssistant from '../components/ai/AiAssistant';
-import CompetitorAnalysis from '../components/ai/CompetitorAnalysis';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
+import ProductOptimizer from '@/components/ai/ProductOptimizer';
+import AiAssistant from '@/components/ai/AiAssistant';
+import CompetitorAnalysis from '@/components/ai/CompetitorAnalysis';
 
 const AiHub: React.FC = () => {
   const [activeTab, setActiveTab] = useState('assistant');

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -26,7 +26,7 @@ import {
   ResponsiveContainer 
 } from 'recharts';
 
-import { useShop } from '../contexts/ShopContext';
+import { useShop } from '@/contexts/ShopContext';
 
 // Mock analytics data
 const salesData = [

--- a/src/pages/CustomReports.tsx
+++ b/src/pages/CustomReports.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { BarChart, Bar, LineChart, Line, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import { FileText, Download, Filter, Calendar, RefreshCw, Plus, Trash2, Settings, Loader2 } from 'lucide-react';
 
-import { Button } from '../components/ui/button';
+import { Button } from '@/components/ui/button';
 
 const CustomReports: React.FC = () => {
   const [loading, setLoading] = useState(false);

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,12 +2,12 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { BarChart3, ShoppingBag, TrendingUp, Users, ArrowUpRight, ArrowDownRight, Package, Calendar, Bell, Settings, FileText, Bot, Database, Code, Layers, Webhook } from 'lucide-react';
 
-import { supabase } from '../lib/supabase';
-import SubscriptionOverview from '../components/dashboard/SubscriptionOverview';
-import TrackingWidget from '../components/tracking/TrackingWidget';
-import MainNavbar from '../components/layout/MainNavbar';
-import Footer from '../components/layout/Footer';
-import { Button } from '../components/ui/button';
+import { supabase } from '@/lib/supabase';
+import SubscriptionOverview from '@/components/dashboard/SubscriptionOverview';
+import TrackingWidget from '@/components/tracking/TrackingWidget';
+import MainNavbar from '@/components/layout/MainNavbar';
+import Footer from '@/components/layout/Footer';
+import { Button } from '@/components/ui/button';
 
 export default function Dashboard() {
   const [stats, setStats] = useState({

--- a/src/pages/Dropshipping.tsx
+++ b/src/pages/Dropshipping.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
 import { ShoppingBag, Users, Package, TrendingUp } from 'lucide-react';
 
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
-import ProductFinder from '../components/dropshipping/ProductFinder';
-import SupplierDirectory from '../components/dropshipping/SupplierDirectory';
-import OrderFulfillment from '../components/dropshipping/OrderFulfillment';
-import SupplierCatalogImporter from '../components/import/SupplierCatalogImporter';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import ProductFinder from '@/components/dropshipping/ProductFinder';
+import SupplierDirectory from '@/components/dropshipping/SupplierDirectory';
+import OrderFulfillment from '@/components/dropshipping/OrderFulfillment';
+import SupplierCatalogImporter from '@/components/import/SupplierCatalogImporter';
 
 const Dropshipping: React.FC = () => {
   const [activeTab, setActiveTab] = useState('products');

--- a/src/pages/GlobalMarketplaces.tsx
+++ b/src/pages/GlobalMarketplaces.tsx
@@ -12,9 +12,9 @@ import {
   Loader2
 } from 'lucide-react';
 
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
-import { Button } from '../components/ui/button';
-import MarketplaceCard from '../components/marketplace/MarketplaceCard';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
+import MarketplaceCard from '@/components/marketplace/MarketplaceCard';
 
 interface Marketplace {
   id: string;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -26,9 +26,9 @@ import {
   DollarSign
 } from 'lucide-react';
 
-import MainNavbar from '../components/layout/MainNavbar';
-import Footer from '../components/layout/Footer';
-import { Button } from '../components/ui/button';
+import MainNavbar from '@/components/layout/MainNavbar';
+import Footer from '@/components/layout/Footer';
+import { Button } from '@/components/ui/button';
 
 const Home: React.FC = () => {
   return (

--- a/src/pages/ImportProducts.tsx
+++ b/src/pages/ImportProducts.tsx
@@ -26,18 +26,18 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { useShop } from '../contexts/ShopContext';
-import { Button } from '../components/ui/button';
-import CSVImporter from '../components/import/CSVImporter';
-import JSONImporter from '../components/import/JSONImporter';
-import XMLImporter from '../components/import/XMLImporter';
-import ImageImporter from '../components/import/ImageImporter';
-import URLImporter from '../components/import/URLImporter';
-import FTPImporter from '../components/import/FTPImporter';
-import MarketplaceImporter from '../components/import/MarketplaceImporter';
-import SupplierCatalogImporter from '../components/import/SupplierCatalogImporter';
-import MainNavbar from '../components/layout/MainNavbar';
-import Footer from '../components/layout/Footer';
+import { useShop } from '@/contexts/ShopContext';
+import { Button } from '@/components/ui/button';
+import CSVImporter from '@/components/import/CSVImporter';
+import JSONImporter from '@/components/import/JSONImporter';
+import XMLImporter from '@/components/import/XMLImporter';
+import ImageImporter from '@/components/import/ImageImporter';
+import URLImporter from '@/components/import/URLImporter';
+import FTPImporter from '@/components/import/FTPImporter';
+import MarketplaceImporter from '@/components/import/MarketplaceImporter';
+import SupplierCatalogImporter from '@/components/import/SupplierCatalogImporter';
+import MainNavbar from '@/components/layout/MainNavbar';
+import Footer from '@/components/layout/Footer';
 
 
 const importMethods = [

--- a/src/pages/Integrations.tsx
+++ b/src/pages/Integrations.tsx
@@ -6,10 +6,10 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
-import IntegrationCard from '../components/integrations/IntegrationCard';
-import ApiIntegration from '../components/integrations/ApiIntegration';
-import { Button } from '../components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import IntegrationCard from '@/components/integrations/IntegrationCard';
+import ApiIntegration from '@/components/integrations/ApiIntegration';
+import { Button } from '@/components/ui/button';
 
 
 const Integrations: React.FC = () => {

--- a/src/pages/InternationalSelling.tsx
+++ b/src/pages/InternationalSelling.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { Globe, DollarSign, Languages, Truck, Settings, Check, AlertTriangle } from 'lucide-react';
 
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
-import { Button } from '../components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
 
 const InternationalSelling: React.FC = () => {
   const [activeTab, setActiveTab] = useState('markets');

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { ShoppingBag } from 'lucide-react';
 
-import LoginForm from '../components/auth/LoginForm';
-import MainNavbar from '../components/layout/MainNavbar';
-import Footer from '../components/layout/Footer';
+import LoginForm from '@/components/auth/LoginForm';
+import MainNavbar from '@/components/layout/MainNavbar';
+import Footer from '@/components/layout/Footer';
 
 const LoginPage: React.FC = () => {
   return (

--- a/src/pages/MarketingHub.tsx
+++ b/src/pages/MarketingHub.tsx
@@ -15,8 +15,8 @@ import {
   Filter
 } from 'lucide-react';
 
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
-import { Button } from '../components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
 
 const MarketingHub: React.FC = () => {
   const [activeTab, setActiveTab] = useState('email');

--- a/src/pages/MultiChannel.tsx
+++ b/src/pages/MultiChannel.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import { Store, Share2, BarChart, Settings } from 'lucide-react';
 
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
-import ChannelManager from '../components/multichannel/ChannelManager';
-import ProductPublisher from '../components/multichannel/ProductPublisher';
-import BulkActions from '../components/automation/BulkActions';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import ChannelManager from '@/components/multichannel/ChannelManager';
+import ProductPublisher from '@/components/multichannel/ProductPublisher';
+import BulkActions from '@/components/automation/BulkActions';
 
 const MultiChannel: React.FC = () => {
   const [activeTab, setActiveTab] = useState('channels');

--- a/src/pages/MultiChannelIntegrations.tsx
+++ b/src/pages/MultiChannelIntegrations.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { ShoppingBag } from 'lucide-react';
 
-import IntegrationCard from '../components/integrations/IntegrationCard';
-import { Badge } from '../components/ui/badge';
+import IntegrationCard from '@/components/integrations/IntegrationCard';
+import { Badge } from '@/components/ui/badge';
 
 interface Platform {
   id: string;

--- a/src/pages/MultiPlatformIntegration.tsx
+++ b/src/pages/MultiPlatformIntegration.tsx
@@ -12,13 +12,13 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
-import PlatformConnector from '../components/integrations/PlatformConnector';
-import SyncSettings, { SyncSettings as SyncSettingsType } from '../components/integrations/SyncSettings';
-import CategoryMapping, { CategoryMapping as CategoryMappingType } from '../components/integrations/CategoryMapping';
-import SyncHistory from '../components/integrations/SyncHistory';
-import NotificationSettings, { NotificationSettings as NotificationSettingsType } from '../components/integrations/NotificationSettings';
-import { Button } from '../components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import PlatformConnector from '@/components/integrations/PlatformConnector';
+import SyncSettings, { SyncSettings as SyncSettingsType } from '@/components/integrations/SyncSettings';
+import CategoryMapping, { CategoryMapping as CategoryMappingType } from '@/components/integrations/CategoryMapping';
+import SyncHistory from '@/components/integrations/SyncHistory';
+import NotificationSettings, { NotificationSettings as NotificationSettingsType } from '@/components/integrations/NotificationSettings';
+import { Button } from '@/components/ui/button';
 
 
 const MultiPlatformIntegration: React.FC = () => {

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -11,7 +11,7 @@ import {
 } from 'lucide-react';
 import { motion } from 'framer-motion';
 
-import { useShop } from '../contexts/ShopContext';
+import { useShop } from '@/contexts/ShopContext';
 
 // Mock order data
 const mockOrders = [

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 
-import { supabase } from '../lib/supabase';
-import PricingCard from '../components/stripe/PricingCard';
-import { stripeProducts } from '../stripe-config';
+import { supabase } from '@/lib/supabase';
+import PricingCard from '@/components/stripe/PricingCard';
+import { stripeProducts } from '@/stripe-config';
 
 const Pricing: React.FC = () => {
   const [currentPlan, setCurrentPlan] = useState<string | null>(null);

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { supabase } from '../lib/supabase';
-import { aiService } from '../services/aiService';
+import { supabase } from '@/lib/supabase';
+import { aiService } from '@/services/aiService';
 
 const Products = () => {
   const [products, setProducts] = useState<any[]>([]);

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -3,13 +3,13 @@ import { Link, useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { User, Mail, Lock, ArrowRight, Loader2, AlertCircle } from 'lucide-react';
 
-import Logo from '../components/layout/Logo';
-import { supabase } from '../lib/supabase';
-import { Input } from '../components/ui/input';
-import { Button } from '../components/ui/button';
-import MainNavbar from '../components/layout/MainNavbar';
-import RegisterForm from '../components/auth/RegisterForm';
-import Footer from '../components/layout/Footer';
+import Logo from '@/components/layout/Logo';
+import { supabase } from '@/lib/supabase';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import MainNavbar from '@/components/layout/MainNavbar';
+import RegisterForm from '@/components/auth/RegisterForm';
+import Footer from '@/components/layout/Footer';
 
 const Register: React.FC = () => {
   return (

--- a/src/pages/Reviews.tsx
+++ b/src/pages/Reviews.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { MessageSquare, Search, Filter, SlidersHorizontal, Star, ThumbsUp } from 'lucide-react';
 import { motion } from 'framer-motion';
 
-import { useShop } from '../contexts/ShopContext';
+import { useShop } from '@/contexts/ShopContext';
 
 // Mock reviews data
 const mockReviews = [

--- a/src/pages/SeoAudit.tsx
+++ b/src/pages/SeoAudit.tsx
@@ -1,4 +1,4 @@
-import SeoAuditForm from "../components/SeoAuditForm";
+import SeoAuditForm from "@/components/SeoAuditForm";
 
 export default function SeoAuditPage() {
   return (

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
-import MfaSettings from '../components/auth/MfaSettings';
-import { availableLanguages, useLanguage } from '../contexts/LanguageContext';
-import { availableCurrencies, useCurrency } from '../contexts/CurrencyContext';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import MfaSettings from '@/components/auth/MfaSettings';
+import { availableLanguages, useLanguage } from '@/contexts/LanguageContext';
+import { availableCurrencies, useCurrency } from '@/contexts/CurrencyContext';
 
 const Settings = () => {
   const { currentLanguage, setLanguage } = useLanguage();

--- a/src/pages/Success.tsx
+++ b/src/pages/Success.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { CheckCircle, Loader2 } from 'lucide-react';
 import { motion } from 'framer-motion';
 
-import { supabase } from '../lib/supabase';
+import { supabase } from '@/lib/supabase';
 
 const Success: React.FC = () => {
   const [searchParams] = useSearchParams();

--- a/src/pages/Suppliers.tsx
+++ b/src/pages/Suppliers.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { supabase } from '../lib/supabase';
+import { supabase } from '@/lib/supabase';
 
 const Suppliers = () => {
   const [suppliers, setSuppliers] = useState([]);

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { HelpCircle, MessageSquare, Mail, Phone, Video, FileText, Book, CheckCircle, Clock, Calendar } from 'lucide-react';
 import { motion } from 'framer-motion';
 
-import { Button } from '../components/ui/button';
+import { Button } from '@/components/ui/button';
 
 const Support: React.FC = () => {
   const supportChannels = [

--- a/src/pages/Webhooks.tsx
+++ b/src/pages/Webhooks.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { Plus, Trash2, Copy, Check, RefreshCw, Loader2, AlertCircle } from 'lucide-react';
 
-import { supabase } from '../lib/supabase';
-import { Button } from '../components/ui/button';
+import { supabase } from '@/lib/supabase';
+import { Button } from '@/components/ui/button';
 
 interface Webhook {
   id: string;

--- a/src/pages/WinningProducts.tsx
+++ b/src/pages/WinningProducts.tsx
@@ -12,7 +12,7 @@ import {
   Loader2
 } from 'lucide-react';
 
-import { Button } from '../components/ui/button';
+import { Button } from '@/components/ui/button';
 
 interface Product {
   id: string;

--- a/src/pages/ab-testing/index.tsx
+++ b/src/pages/ab-testing/index.tsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { SplitSquareVertical, Plus, BarChart3, Play, Pause, Archive, Edit, Trash2, Copy, Search, Filter, CheckCircle, Clock, AlertCircle } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { abTestingService, ABTest, ABTestResult } from '../../modules/ab-testing';
-import { Button } from '../../components/ui/button';
+import { abTestingService, ABTest, ABTestResult } from '@/modules/ab-testing';
+import { Button } from '@/components/ui/button';
 
 
 const ABTestingPage: React.FC = () => {

--- a/src/pages/accounting/index.tsx
+++ b/src/pages/accounting/index.tsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { FileText, Plus, Download, Printer, Search, Filter, DollarSign, Calendar, CheckCircle, Clock, AlertCircle } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { accountingService, Invoice } from '../../modules/accounting';
-import { Button } from '../../components/ui/button';
+import { accountingService, Invoice } from '@/modules/accounting';
+import { Button } from '@/components/ui/button';
 
 
 const AccountingPage: React.FC = () => {

--- a/src/pages/admin/Analytics.tsx
+++ b/src/pages/admin/Analytics.tsx
@@ -2,9 +2,9 @@ import React, { useState, useEffect } from 'react';
 import { BarChart3, TrendingUp, DollarSign, Users, Calendar, Download, ArrowUpRight, ArrowDownRight } from 'lucide-react';
 import { Navigate } from 'react-router-dom';
 
-import { supabase } from '../../lib/supabase';
-import { useRole } from '../../context/RoleContext';
-import { Button } from '../../components/ui/button';
+import { supabase } from '@/lib/supabase';
+import { useRole } from '@/context/RoleContext';
+import { Button } from '@/components/ui/button';
 
 
 const AdminAnalytics: React.FC = () => {

--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -2,10 +2,10 @@ import React, { useEffect, useState } from 'react';
 import { BarChart3, Users, ShoppingBag, DollarSign, ArrowUpRight, ArrowDownRight } from 'lucide-react';
 import { Navigate } from 'react-router-dom';
 
-import { supabase } from '../../lib/supabase';
-import { useRole } from '../../context/RoleContext';
-import { Button } from '../../components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
+import { supabase } from '@/lib/supabase';
+import { useRole } from '@/context/RoleContext';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 
 const AdminDashboard: React.FC = () => {

--- a/src/pages/admin/Imports.tsx
+++ b/src/pages/admin/Imports.tsx
@@ -18,10 +18,10 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { supabase } from '../../lib/supabase';
-import { supplierService } from '../../services/supplierService';
-import { ExternalSupplier, SupplierProduct, ImportFilter } from '../../types/supplier';
-import { Button } from '../../components/ui/button';
+import { supabase } from '@/lib/supabase';
+import { supplierService } from '@/services/supplierService';
+import { ExternalSupplier, SupplierProduct, ImportFilter } from '@/types/supplier';
+import { Button } from '@/components/ui/button';
 
 
 const Imports: React.FC = () => {

--- a/src/pages/admin/Users.tsx
+++ b/src/pages/admin/Users.tsx
@@ -2,9 +2,9 @@ import React, { useEffect, useState } from 'react';
 import { Users as UsersIcon, Search, Filter, Edit, Trash, UserPlus, CheckCircle, XCircle } from 'lucide-react';
 import { Navigate } from 'react-router-dom';
 
-import { supabase } from '../../lib/supabase';
-import { useRole } from '../../context/RoleContext';
-import { Button } from '../../components/ui/button';
+import { supabase } from '@/lib/supabase';
+import { useRole } from '@/context/RoleContext';
+import { Button } from '@/components/ui/button';
 
 
 interface User {

--- a/src/pages/auth/AuthCallback.tsx
+++ b/src/pages/auth/AuthCallback.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Loader2, CheckCircle, AlertCircle } from 'lucide-react';
 
-import { supabase } from '../../lib/supabase';
-import { Button } from '../../components/ui/button';
+import { supabase } from '@/lib/supabase';
+import { Button } from '@/components/ui/button';
 
 const AuthCallback: React.FC = () => {
   const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading');

--- a/src/pages/blog-ai.tsx
+++ b/src/pages/blog-ai.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { Loader2, Copy, Check, Download, ArrowRight } from 'lucide-react';
 
-import MainNavbar from '../components/layout/MainNavbar';
-import Footer from '../components/layout/Footer';
+import MainNavbar from '@/components/layout/MainNavbar';
+import Footer from '@/components/layout/Footer';
 
 import { askChatGPT } from '@/lib/openai';
 import { Input } from '@/components/ui/input';

--- a/src/pages/chat-support/index.tsx
+++ b/src/pages/chat-support/index.tsx
@@ -2,9 +2,9 @@ import React, { useState, useEffect, useRef } from 'react';
 import { MessageSquare, Send, User, Bot, Loader2, Clock, ArrowLeft, MoreVertical } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { chatService, ChatMessage, ChatSession } from '../../modules/chat';
-import { supabase } from '../../lib/supabase';
-import { Button } from '../../components/ui/button';
+import { chatService, ChatMessage, ChatSession } from '@/modules/chat';
+import { supabase } from '@/lib/supabase';
+import { Button } from '@/components/ui/button';
 
 
 const ChatSupportPage: React.FC = () => {

--- a/src/pages/funnels/index.tsx
+++ b/src/pages/funnels/index.tsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { GitBranch, Plus, BarChart3, Edit, Trash2, Play, Pause, Copy, Search, Filter, ArrowRight } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { funnelService, Funnel } from '../../modules/funnels';
-import { Button } from '../../components/ui/button';
+import { funnelService, Funnel } from '@/modules/funnels';
+import { Button } from '@/components/ui/button';
 
 
 const FunnelsPage: React.FC = () => {

--- a/src/pages/generateInvoice.tsx
+++ b/src/pages/generateInvoice.tsx
@@ -4,8 +4,8 @@ import jsPDF from 'jspdf';
 import 'jspdf-autotable';
 import { Loader2, Download, Plus, Trash2, FileText, Calendar, DollarSign, User, Building } from 'lucide-react';
 
-import MainNavbar from '../components/layout/MainNavbar';
-import Footer from '../components/layout/Footer';
+import MainNavbar from '@/components/layout/MainNavbar';
+import Footer from '@/components/layout/Footer';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';

--- a/src/pages/inventory/index.tsx
+++ b/src/pages/inventory/index.tsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { Package, AlertTriangle, Settings, RefreshCw, Search, Filter, CheckCircle, XCircle, Bell } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { inventoryService, StockAlert, InventorySettings } from '../../modules/inventory';
-import { Button } from '../../components/ui/button';
+import { inventoryService, StockAlert, InventorySettings } from '@/modules/inventory';
+import { Button } from '@/components/ui/button';
 
 
 const InventoryPage: React.FC = () => {

--- a/src/pages/marketplace-b2b.tsx
+++ b/src/pages/marketplace-b2b.tsx
@@ -15,8 +15,8 @@ import {
 import { motion } from 'framer-motion';
 import { toast } from 'sonner';
 
-import MainNavbar from '../components/layout/MainNavbar';
-import Footer from '../components/layout/Footer';
+import MainNavbar from '@/components/layout/MainNavbar';
+import Footer from '@/components/layout/Footer';
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { b2bService, B2BSupplier } from '@/services/b2bService';

--- a/src/pages/repricing/index.tsx
+++ b/src/pages/repricing/index.tsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { DollarSign, Plus, Trash2, Save, Percent, Settings, RefreshCw, TrendingUp, Search, Filter } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { repricingService, PricingRule } from '../../modules/repricing';
-import { Button } from '../../components/ui/button';
+import { repricingService, PricingRule } from '@/modules/repricing';
+import { Button } from '@/components/ui/button';
 
 
 const RepricingPage: React.FC = () => {

--- a/src/pages/returns/index.tsx
+++ b/src/pages/returns/index.tsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { Package, Search, Filter, CheckCircle, XCircle, ArrowLeft, Truck, DollarSign, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { returnsService, ReturnRequest } from '../../modules/returns';
-import { Button } from '../../components/ui/button';
+import { returnsService, ReturnRequest } from '@/modules/returns';
+import { Button } from '@/components/ui/button';
 
 
 const ReturnsPage: React.FC = () => {

--- a/src/pages/seo-ai.tsx
+++ b/src/pages/seo-ai.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { Loader2, Copy, Check, Download, ArrowRight } from 'lucide-react';
 
-import MainNavbar from '../components/layout/MainNavbar';
-import Footer from '../components/layout/Footer';
+import MainNavbar from '@/components/layout/MainNavbar';
+import Footer from '@/components/layout/Footer';
 
 import { askChatGPT } from '@/lib/openai';
 import { Input } from '@/components/ui/input';

--- a/src/pages/templates/index.tsx
+++ b/src/pages/templates/index.tsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { FileText, Plus, Search, Filter, Edit, Trash2, Copy, Eye, Sparkles } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { templateService, Template } from '../../modules/templates';
-import { Button } from '../../components/ui/button';
+import { templateService, Template } from '@/modules/templates';
+import { Button } from '@/components/ui/button';
 
 
 const TemplatesPage: React.FC = () => {

--- a/src/pages/tracking.tsx
+++ b/src/pages/tracking.tsx
@@ -4,13 +4,13 @@ import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
 import { Package, AlertTriangle } from 'lucide-react';
 
-import { trackingService, TrackingResult } from '../services/trackingService';
-import TrackingForm from '../components/tracking/TrackingForm';
-import TrackingResultComponent from '../components/tracking/TrackingResult';
-import RecentTrackings from '../components/tracking/RecentTrackings';
-import BulkTrackingForm from '../components/tracking/BulkTrackingForm';
-import MainNavbar from '../components/layout/MainNavbar';
-import Footer from '../components/layout/Footer';
+import { trackingService, TrackingResult } from '@/services/trackingService';
+import TrackingForm from '@/components/tracking/TrackingForm';
+import TrackingResultComponent from '@/components/tracking/TrackingResult';
+import RecentTrackings from '@/components/tracking/RecentTrackings';
+import BulkTrackingForm from '@/components/tracking/BulkTrackingForm';
+import MainNavbar from '@/components/layout/MainNavbar';
+import Footer from '@/components/layout/Footer';
 
 export default function TrackingPage() {
   const { t } = useTranslation('tracking');

--- a/src/services/b2bService.ts
+++ b/src/services/b2bService.ts
@@ -1,4 +1,4 @@
-import { supabase } from '../lib/supabase';
+import { supabase } from '@/lib/supabase';
 
 export interface B2BSupplier {
   id: string;

--- a/src/services/importService.ts
+++ b/src/services/importService.ts
@@ -3,7 +3,7 @@ import { parseString } from 'xml2js';
 import axios from 'axios';
 import * as cheerio from 'cheerio';
 
-import { supabase } from '../lib/supabase';
+import { supabase } from '@/lib/supabase';
 
 import { aiService } from './aiService';
 import { supplierService } from './supplierService';

--- a/src/services/orderService.ts
+++ b/src/services/orderService.ts
@@ -1,4 +1,4 @@
-import { supabase } from '../lib/supabase';
+import { supabase } from '@/lib/supabase';
 
 import { supplierService } from './supplierService';
 

--- a/src/services/platformService.ts
+++ b/src/services/platformService.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import { supabase } from '../lib/supabase';
+import { supabase } from '@/lib/supabase';
 
 export interface Platform {
   id: string;

--- a/src/services/supplierService.ts
+++ b/src/services/supplierService.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
-import { supabase } from '../lib/supabase';
-import { ExternalSupplier, SupplierProduct, ImportFilter, ImportResult, OrderRequest, OrderResult } from '../types/supplier';
+import { supabase } from '@/lib/supabase';
+import { ExternalSupplier, SupplierProduct, ImportFilter, ImportResult, OrderRequest, OrderResult } from '@/types/supplier';
 
 export const supplierService = {
   async getSuppliers(): Promise<ExternalSupplier[]> {

--- a/src/services/syncService.ts
+++ b/src/services/syncService.ts
@@ -1,4 +1,4 @@
-import { supabase } from '../lib/supabase';
+import { supabase } from '@/lib/supabase';
 
 import { supplierService } from './supplierService';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,11 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
   test: {
     environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
   },
 });


### PR DESCRIPTION
## Summary
- define `@` alias in `tsconfig.json` and vitest config
- switch internal imports to use `@/` paths
- fix tests to work with new alias

## Testing
- `npm run build` *(fails: TS2322 etc.)*
- `npm test --silent --run`

------
https://chatgpt.com/codex/tasks/task_e_6865580525448328aabb128ecc1fc353