### PR TITLE
Add AutoDS order API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ Ajoutez les variables suivantes à votre fichier `.env` selon les services utili
 
 * `ZAPIER_WEBHOOK_URL` *(optionnel)* – URL de base pour les hooks Zapier.
 
+### 📡 Routes API AutoDS
+
+Ces routes simulées permettent d'interagir avec le fournisseur AutoDS via les fonctions Supabase :
+
+* `POST /functions/v1/providers/autods` – récupérer des produits
+* `POST /functions/v1/providers/autods/categories` – lister les catégories
+* `POST /functions/v1/providers/autods/orders` – créer une commande
+* `GET  /functions/v1/providers/autods/orders/{id}` – vérifier le statut d'une commande
+
 2. 🚀 Déployer sur Vercel :
 
 ```bash

--- a/src/services/__tests__/supplierService.test.ts
+++ b/src/services/__tests__/supplierService.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('axios', () => ({ default: { post: vi.fn(), get: vi.fn() } }))
+vi.mock('../../lib/supabase', () => ({ supabase: { auth: { getSession: vi.fn().mockResolvedValue({ data: { session: { access_token: 'tok' } } }) } } }))
+
+import axios from 'axios'
+import { supplierService } from '../supplierService'
+
+beforeEach(() => {
+  vi.spyOn(supplierService, 'getSupplierById').mockResolvedValue({
+    id: '1',
+    type: 'autods',
+    apiKey: 'k',
+    apiSecret: 's',
+    baseUrl: 'https://api.autods.com',
+    name: 'AutoDS'
+  } as any)
+  ;(axios.post as any).mockClear()
+  ;(axios.get as any).mockClear()
+})
+
+it('calls AutoDS categories endpoint', async () => {
+  ;(axios.post as any).mockResolvedValueOnce({ data: { categories: [] } })
+  await supplierService.getCategories('1')
+  expect((axios.post as any).mock.calls[0][0]).toContain('/providers/autods/categories')
+})
+
+it('creates order via AutoDS endpoint', async () => {
+  ;(axios.post as any).mockResolvedValueOnce({ data: { success: true } })
+  await supplierService.createOrder('1', { external_order_id: '1', shipping_address: {}, items: [] })
+  expect((axios.post as any).mock.calls[0][0]).toContain('/providers/autods/orders')
+})
+
+it('checks order status via AutoDS endpoint', async () => {
+  ;(axios.get as any).mockResolvedValueOnce({ data: { status: 'processing' } })
+  await supplierService.getOrderStatus('1', '100')
+  expect((axios.get as any).mock.calls[0][0]).toContain('/providers/autods/orders/100')
+})

--- a/src/services/supplierService.ts
+++ b/src/services/supplierService.ts
@@ -207,7 +207,11 @@ export const supplierService = {
       const supplier = await this.getSupplierById(supplierId);
       
       // Call the appropriate API endpoint based on supplier type
-      const apiUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/providers/${supplier.type}/categories`;
+      if (supplier.type !== 'autods') {
+        throw new Error('Categories not supported for this supplier');
+      }
+
+      const apiUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/providers/autods/categories`;
       
       const response = await axios.post(apiUrl, {
         supplierId,
@@ -283,7 +287,11 @@ export const supplierService = {
       const supplier = await this.getSupplierById(supplierId);
       
       // Call the appropriate API endpoint based on supplier type
-      const apiUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/providers/${supplier.type}/orders`;
+      if (supplier.type !== 'autods') {
+        throw new Error('Order creation not supported for this supplier');
+      }
+
+      const apiUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/providers/autods/orders`;
       
       const response = await axios.post(apiUrl, {
         supplierId,
@@ -315,7 +323,11 @@ export const supplierService = {
       const supplier = await this.getSupplierById(supplierId);
       
       // Call the appropriate API endpoint based on supplier type
-      const apiUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/providers/${supplier.type}/orders/${externalOrderId}`;
+      if (supplier.type !== 'autods') {
+        throw new Error('Order status not supported for this supplier');
+      }
+
+      const apiUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/providers/autods/orders/${externalOrderId}`;
       
       const response = await axios.get(apiUrl, {
         headers: {

--- a/supabase/functions/providers/autods/index.ts
+++ b/supabase/functions/providers/autods/index.ts
@@ -21,104 +21,24 @@ serve(async (req) => {
   }
 
   try {
-    const { apiKey, apiSecret, baseUrl, filters, productId, productIds } = await req.json();
+    const url = new URL(req.url);
+    const segments = url.pathname.split("/");
+    const last = segments.pop() || "";
+    const prev = segments.pop() || "";
 
-    if (!apiKey) {
-      throw new Error("API key is required");
+    if (last === "categories") {
+      return await handleCategories(req);
     }
 
-    const apiBase = baseUrl || "https://dummyjson.com";
-    let products: any[] = [];
-
-    try {
-      if (productId) {
-        const res = await fetch(`${apiBase}/products/${productId}`);
-        if (res.ok) {
-          const data = await res.json();
-          products = [data];
-        }
-      } else {
-        const res = await fetch(`${apiBase}/products`);
-        if (res.ok) {
-          const data = await res.json();
-          products = data.products || [];
-        }
-      }
-    } catch (_) {
-      // ignore network errors and fall back to demo data
+    if (last === "orders" && req.method === "POST") {
+      return await handleCreateOrder(req);
     }
 
-    if (products.length === 0) {
-      products = Array(20).fill(0).map((_, i) => ({
-        id: i + 1,
-        title: `AutoDS Demo Product ${i + 1}`,
-        description: `Sample product from AutoDS demo API.`,
-        price: Math.floor(Math.random() * 100) + 10,
-        stock: Math.floor(Math.random() * 100) + 5,
-        category: ['Electronics', 'Fashion', 'Home', 'Beauty'][Math.floor(Math.random() * 4)],
-        images: [
-          `https://images.pexels.com/photos/${1020000 + i * 5}/pexels-photo-${1020000 + i * 5}.jpeg?auto=compress&cs=tinysrgb&w=300`
-        ]
-      }));
+    if (prev === "orders" && last) {
+      return await handleOrderStatus(req, last);
     }
 
-    const mapped = products.map((p, idx) => ({
-      id: `ad-${p.id ?? idx + 1}`,
-      externalId: String(p.id ?? idx + 1),
-      name: p.title || `AutoDS Product ${idx + 1}`,
-      description: p.description || 'AutoDS product',
-      price: p.price ?? Math.floor(Math.random() * 100) + 10,
-      msrp: (p.price ? Math.round(p.price * 1.2) : Math.floor(Math.random() * 150) + 20),
-      stock: p.stock ?? Math.floor(Math.random() * 100) + 5,
-      images: p.images && Array.isArray(p.images) ? p.images : [p.thumbnail].filter(Boolean),
-      category: p.category || 'General',
-      supplier_id: "autods",
-      supplier_type: "autods",
-      shipping_time: `${Math.floor(Math.random() * 10) + 3} days`,
-      processing_time: `${Math.floor(Math.random() * 3) + 1} days`,
-    }));
-
-    let filteredProducts = [...mapped];
-
-    if (filters) {
-      if (filters.category) {
-        filteredProducts = filteredProducts.filter(p => p.category === filters.category);
-      }
-      if (filters.minPrice) {
-        filteredProducts = filteredProducts.filter(p => p.price >= filters.minPrice);
-      }
-      if (filters.maxPrice) {
-        filteredProducts = filteredProducts.filter(p => p.price <= filters.maxPrice);
-      }
-      if (filters.search) {
-        const searchLower = filters.search.toLowerCase();
-        filteredProducts = filteredProducts.filter(p =>
-          p.name.toLowerCase().includes(searchLower) ||
-          p.description.toLowerCase().includes(searchLower)
-        );
-      }
-      if (filters.page && filters.limit) {
-        const start = (filters.page - 1) * filters.limit;
-        const end = start + filters.limit;
-        filteredProducts = filteredProducts.slice(start, end);
-      }
-    }
-
-    if (productIds && Array.isArray(productIds) && productIds.length > 0) {
-      filteredProducts = filteredProducts.filter(p => productIds.includes(p.externalId));
-    }
-
-    return new Response(
-      JSON.stringify({
-        products: filteredProducts,
-        total: mapped.length,
-        filtered: filteredProducts.length,
-        product: filteredProducts.length === 1 && productId ? filteredProducts[0] : undefined
-      }),
-      {
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      }
-    );
+    return await handleProducts(req);
   } catch (error) {
     return new Response(
       JSON.stringify({ error: error.message }),
@@ -129,3 +49,155 @@ serve(async (req) => {
     );
   }
 });
+
+async function handleProducts(req: Request) {
+  const { apiKey, apiSecret, baseUrl, filters, productId, productIds } = await req.json();
+
+  if (!apiKey) {
+    throw new Error("API key is required");
+  }
+
+  const apiBase = baseUrl || "https://dummyjson.com";
+  let products: any[] = [];
+
+  try {
+    if (productId) {
+      const res = await fetch(`${apiBase}/products/${productId}`);
+      if (res.ok) {
+        const data = await res.json();
+        products = [data];
+      }
+    } else {
+      const res = await fetch(`${apiBase}/products`);
+      if (res.ok) {
+        const data = await res.json();
+        products = data.products || [];
+      }
+    }
+  } catch (_) {
+    // ignore network errors and fall back to demo data
+  }
+
+  if (products.length === 0) {
+    products = Array(20).fill(0).map((_, i) => ({
+      id: i + 1,
+      title: `AutoDS Demo Product ${i + 1}`,
+      description: `Sample product from AutoDS demo API.`,
+      price: Math.floor(Math.random() * 100) + 10,
+      stock: Math.floor(Math.random() * 100) + 5,
+      category: ["Electronics", "Fashion", "Home", "Beauty"][Math.floor(Math.random() * 4)],
+      images: [
+        `https://images.pexels.com/photos/${1020000 + i * 5}/pexels-photo-${1020000 + i * 5}.jpeg?auto=compress&cs=tinysrgb&w=300`
+      ]
+    }));
+  }
+
+  const mapped = products.map((p, idx) => ({
+    id: `ad-${p.id ?? idx + 1}`,
+    externalId: String(p.id ?? idx + 1),
+    name: p.title || `AutoDS Product ${idx + 1}`,
+    description: p.description || "AutoDS product",
+    price: p.price ?? Math.floor(Math.random() * 100) + 10,
+    msrp: p.price ? Math.round(p.price * 1.2) : Math.floor(Math.random() * 150) + 20,
+    stock: p.stock ?? Math.floor(Math.random() * 100) + 5,
+    images: p.images && Array.isArray(p.images) ? p.images : [p.thumbnail].filter(Boolean),
+    category: p.category || "General",
+    supplier_id: "autods",
+    supplier_type: "autods",
+    shipping_time: `${Math.floor(Math.random() * 10) + 3} days`,
+    processing_time: `${Math.floor(Math.random() * 3) + 1} days`,
+  }));
+
+  let filteredProducts = [...mapped];
+
+  if (filters) {
+    if (filters.category) {
+      filteredProducts = filteredProducts.filter((p) => p.category === filters.category);
+    }
+    if (filters.minPrice) {
+      filteredProducts = filteredProducts.filter((p) => p.price >= filters.minPrice);
+    }
+    if (filters.maxPrice) {
+      filteredProducts = filteredProducts.filter((p) => p.price <= filters.maxPrice);
+    }
+    if (filters.search) {
+      const searchLower = filters.search.toLowerCase();
+      filteredProducts = filteredProducts.filter((p) =>
+        p.name.toLowerCase().includes(searchLower) ||
+        p.description.toLowerCase().includes(searchLower)
+      );
+    }
+    if (filters.page && filters.limit) {
+      const start = (filters.page - 1) * filters.limit;
+      const end = start + filters.limit;
+      filteredProducts = filteredProducts.slice(start, end);
+    }
+  }
+
+  if (productIds && Array.isArray(productIds) && productIds.length > 0) {
+    filteredProducts = filteredProducts.filter((p) => productIds.includes(p.externalId));
+  }
+
+  return new Response(
+    JSON.stringify({
+      products: filteredProducts,
+      total: mapped.length,
+      filtered: filteredProducts.length,
+      product: filteredProducts.length === 1 && productId ? filteredProducts[0] : undefined,
+    }),
+    {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    }
+  );
+}
+
+async function handleCategories(_req: Request) {
+  const categories = [
+    { id: "electronics", name: "Electronics" },
+    { id: "fashion", name: "Fashion" },
+    { id: "home", name: "Home" },
+    { id: "beauty", name: "Beauty" },
+  ];
+  return new Response(JSON.stringify({ categories }), {
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+async function handleCreateOrder(req: Request) {
+  const { apiKey, order } = await req.json();
+  if (!apiKey) {
+    return new Response(JSON.stringify({ error: "API key is required" }), {
+      status: 400,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+  if (!order) {
+    return new Response(JSON.stringify({ error: "Order data is required" }), {
+      status: 400,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+  const externalOrderId = `AD-${Math.floor(Math.random() * 1000000)}`;
+  return new Response(
+    JSON.stringify({ success: true, externalOrderId, status: "processing" }),
+    {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    }
+  );
+}
+
+async function handleOrderStatus(_req: Request, orderId: string) {
+  const statuses = ["processing", "shipped", "delivered"];
+  const status = statuses[Math.floor(Math.random() * statuses.length)];
+  const trackingNumber = status !== "processing" ? `TRK${Math.floor(Math.random() * 1000000)}` : undefined;
+  const estimatedDelivery = new Date(Date.now() + Math.floor(Math.random() * 7 + 3) * 86400000)
+    .toISOString()
+    .split("T")[0];
+
+  return new Response(
+    JSON.stringify({ orderId, status, trackingNumber, estimatedDelivery }),
+    {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- add categories, order creation and status routes in autoDS provider
- restrict supplierService to use new routes for AutoDS
- document AutoDS routes
- test supplierService endpoints

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68655ef2080483288d8bd060dd57266d