### PR TITLE
Fix OpenAI key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ ZAPIER_WEBHOOK_URL=...
 VITE_CANVA_APP_ID=...
 ```
 
+Le champ `VITE_OPENAI_API_KEY` est obligatoire pour toutes les fonctionnalités IA.
+
 ---
 
 ## 📘 Documentation IA

--- a/src/lib/seoAI.ts
+++ b/src/lib/seoAI.ts
@@ -1,7 +1,17 @@
 import { OpenAI } from 'openai';
 
+const apiKey =
+  import.meta.env.VITE_OPENAI_API_KEY || process.env.VITE_OPENAI_API_KEY;
+
+if (!apiKey) {
+  console.error(
+    'VITE_OPENAI_API_KEY is not defined. Set this value in your .env file.'
+  );
+  throw new Error('VITE_OPENAI_API_KEY is not defined');
+}
+
 const openai = new OpenAI({
-  apiKey: import.meta.env.VITE_OPENAI_API_KEY,
+  apiKey,
   dangerouslyAllowBrowser: true
 });
 

--- a/src/pages/seo-ai.tsx
+++ b/src/pages/seo-ai.tsx
@@ -63,7 +63,9 @@ Génère un JSON SEO complet avec :
       } catch (parseError) {
         console.error("Erreur de parsing JSON:", parseError);
         // Tentative de récupération du JSON dans la réponse
-        const jsonMatch = raw.match(/```json\n([\s\S]*?)\n```/) || raw.match(/\{[\s\S]*\}/);
+        const jsonMatch =
+          typeof raw === 'string' &&
+          (raw.match(/```json\n([\s\S]*?)\n```/) || raw.match(/\{[\s\S]*\}/));
         if (jsonMatch) {
           try {
             const jsonContent = jsonMatch[1] || jsonMatch[0];

--- a/src/services/__tests__/aiService.test.ts
+++ b/src/services/__tests__/aiService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { it, expect, vi } from 'vitest'
 
 var createMock: any
 vi.mock('openai', () => {
@@ -10,10 +10,15 @@ vi.mock('openai', () => {
   }
 })
 
-import { aiService } from '../aiService'
-
 it('parses variant suggestions from OpenAI', async () => {
-  createMock.mockResolvedValue({ choices: [{ message: { content: '[{"title":"Variant A","options":{"size":"S"}}]' } }] })
+  process.env.VITE_OPENAI_API_KEY = 'test-key'
+
+  const { aiService } = await import('../aiService')
+
+  createMock.mockResolvedValue({
+    choices: [{ message: { content: '[{"title":"Variant A","options":{"size":"S"}}]' } }]
+  })
   const result = await aiService.generateVariants({ title: 'Test Product' })
   expect(result).toEqual([{ title: 'Variant A', options: { size: 'S' } }])
 })
+

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -1,7 +1,17 @@
 import OpenAI from 'openai';
 
+const apiKey =
+  import.meta.env.VITE_OPENAI_API_KEY || process.env.VITE_OPENAI_API_KEY;
+
+if (!apiKey) {
+  console.error(
+    'VITE_OPENAI_API_KEY is not defined. Set this value in your .env file.'
+  );
+  throw new Error('VITE_OPENAI_API_KEY is not defined');
+}
+
 const openai = new OpenAI({
-  apiKey: import.meta.env.VITE_OPENAI_API_KEY,
+  apiKey,
   dangerouslyAllowBrowser: true
 });
 


### PR DESCRIPTION
## Summary
- validate `VITE_OPENAI_API_KEY` before creating OpenAI clients
- guard AI SEO page JSON parsing when raw data is undefined
- document that the API key is mandatory
- adjust test to load service after setting env variable

## Testing
- `npx vitest run` *(fails: Cannot install vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6883a0c48c1c832890bce72f829b47e2